### PR TITLE
Rename name to type-name in the context of named types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased][unreleased]
 
+- Unwrap `:type-field-type` for list type for consistency
+- Rename ambiguous `:name` to `:type-name` in the context of named types
+
 ## [0.1.11] - 2016-09-26
 ### Changed
 - Fix test cases

--- a/src/graphql_clj/executor.clj
+++ b/src/graphql_clj/executor.clj
@@ -79,7 +79,7 @@
 
 (defn resolve-field-on-object
   [context schema resolver-fn parent-type parent-object field-entry field-type variables]
-  (let [parent-type-name (:name parent-type)
+  (let [parent-type-name (:type-name parent-type)
         field-name (get-selection-name field-entry)
         field-arguments (type/get-field-arguments parent-type field-name)
         arguments (build-arguments field-entry variables)
@@ -164,7 +164,7 @@
   (assert field-entry (format "field-entry is NULL, for parent-type %s." parent-type))
   (assert parent-type (format "parent-type is NULL, for field-entry %s." field-entry))
   (let [response-key (get-selection-name field-entry)
-        parent-type-name (:name parent-type)
+        parent-type-name (:type-name parent-type)
         field-type (type/get-field-type schema parent-type-name response-key)]
     (assert response-key "response-key is NULL!")
     (if (not (nil? field-type))

--- a/src/graphql_clj/parser.clj
+++ b/src/graphql_clj/parser.clj
@@ -36,12 +36,12 @@
 (defn- to-unwrapped-val [k v] [k (second v)])
 (defn- to-list [_ & args]
   (let [{:keys [type-field-type]} (into {} args)]
-    {:kind :LIST :inner-type type-field-type}))
+    {:kind :LIST :inner-type (set/rename-keys type-field-type {:name :type-name})}))
 
 (defn- add-required [_ arg]
   (cond
     (map? arg) (assoc arg :required true)
-    (and (vector? arg) (= :named-type (first arg))) {:name (last arg) :required true}
+    (and (vector? arg) (= :named-type (first arg))) {:type-name (last arg) :required true}
     :else (throw (ex-info "unexpected to-required arg" arg))))
 
 (defn- to-singular-and-plural [k & args]
@@ -95,7 +95,8 @@
               (merge type-field-type type)
               (set/rename-keys {:type-field-arguments        :arguments
                                 :type-field-argument-default :default-value
-                                :named-type                  :name}))]))
+                                :name                        :type-name
+                                :named-type                  :type-name}))]))
 
 (def ^:private transformations
   "Map from transformation functions to tree tags.

--- a/src/graphql_clj/parser.clj
+++ b/src/graphql_clj/parser.clj
@@ -34,7 +34,9 @@
 (defn- to-val [k v] [k v])
 (defn- to-type-system-type [k & args] (into {:type-system-type (keyword (str/replace (name k) #"-definition" ""))} args))
 (defn- to-unwrapped-val [k v] [k (second v)])
-(defn- to-list [_ & args] {:kind :LIST :inner-type (into {} args)})
+(defn- to-list [_ & args]
+  (let [{:keys [type-field-type]} (into {} args)]
+    {:kind :LIST :inner-type type-field-type}))
 
 (defn- add-required [_ arg]
   (cond
@@ -89,7 +91,7 @@
   (let [{:keys [name type type-field-type] :as m} (into {} args)]
     (assert name "Name is NULL!")
     [name (-> m
-              (dissoc :type-field-type :type)
+              (dissoc :type-field-type :type :name)
               (merge type-field-type type)
               (set/rename-keys {:type-field-arguments        :arguments
                                 :type-field-argument-default :default-value

--- a/src/graphql_clj/resolver.clj
+++ b/src/graphql_clj/resolver.clj
@@ -56,13 +56,13 @@
                                   [])
        ["__Type" "ofType"] (fn [context parent & rest]
                              (if (:inner-type parent)
-                               (type/get-type-in-schema schema (get-in parent [:inner-type :type-field-type :name]))))
+                               (type/get-type-in-schema schema (get-in parent [:inner-type :name]))))
        ["__Field" "name"] (fn [context parent & rest]
                             (let [[name _] parent]
                               name))
        ["__Field" "type"] (fn [context parent & rest]
                             (let [[_ type] parent
-                                  field-type (get-in type [:type-field-type])
+                                  field-type (get-in type [:type-field-type]) ;; TODO probably wrong, as :type-field-type no longer appears in parsed tree
                                   type-name (:name field-type)]
                               (if (:kind field-type)
                                 field-type

--- a/src/graphql_clj/resolver.clj
+++ b/src/graphql_clj/resolver.clj
@@ -11,7 +11,7 @@
 (defn schema-introspection-resolver-fn
   [schema]
   (let [root-query-type (type/get-root-query-type schema)
-        root-query-name (:name root-query-type)]
+        root-query-name (:type-name root-query-type)]
     (fn [type-name field-name]
       (match/match
        [type-name field-name]
@@ -26,7 +26,7 @@
                                        :directives []})
        [root-query-name "__type"] (fn [context parent & args]
                                     {:kind nil
-                                     :name nil
+                                     :type-name nil
                                      :description nil
                                      :fields []
                                      :interfaces []
@@ -56,21 +56,21 @@
                                   [])
        ["__Type" "ofType"] (fn [context parent & rest]
                              (if (:inner-type parent)
-                               (type/get-type-in-schema schema (get-in parent [:inner-type :name]))))
+                               (type/get-type-in-schema schema (get-in parent [:inner-type :type-name]))))
        ["__Field" "name"] (fn [context parent & rest]
                             (let [[name _] parent]
                               name))
        ["__Field" "type"] (fn [context parent & rest]
                             (let [[_ type] parent
                                   field-type (get-in type [:type-field-type]) ;; TODO probably wrong, as :type-field-type no longer appears in parsed tree
-                                  type-name (:name field-type)]
+                                  type-name (:type-name field-type)]
                               (if (:kind field-type)
                                 field-type
                                 (type/get-type-in-schema schema type-name))))
        ["__Field" "args"] (fn [& rest]
                             [])
        ["__EnumValue" "name"] (fn [context parent & rest]
-                                (:name parent))
+                                (:name parent))             ;; TODO probably wrong, could be :type-name
        :else nil))))
 
 (defn create-resolver-fn

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -204,7 +204,7 @@
         inner-type-kind (:kind inner-type)]
     (if inner-type-kind
       inner-type
-      (if-let [inner-type-name (get-in inner-type [:type-field-type :name])]
+      (if-let [inner-type-name (:name inner-type)]
         (get-type-in-schema schema inner-type-name)
         (gerror/throw-error (format "get-inner-type: failed getting inner type of field-type(%s)" field-type))))))
 

--- a/test/graphql_clj/executor_test.clj
+++ b/test/graphql_clj/executor_test.clj
@@ -113,7 +113,6 @@ fragment userFields on User {
 (deftest test-mutation
   (testing "test execution on mutation with argument value"
     (let [user-name "Mutation Test User"
-          variables {"name" user-name}
           mutation (format "mutation {createUser(name: \"%s\") {id name}}" user-name)
           result (execute nil simple-user-schema customized-resolver-fn mutation)]
       (is (= user-name (get-in result

--- a/test/graphql_clj/parser_test.clj
+++ b/test/graphql_clj/parser_test.clj
@@ -414,7 +414,10 @@ type SearchQuery {
     friends {
       name
     }
-  }"])
+  }"
+   "type TripleList {
+      numbers: [[[Int!]]]!
+   }"])
 
 (deftest test-schema
   (doseq [schema test-schemas]


### PR DESCRIPTION
In order to be more consistent and less ambiguous:
- Unwrap `:type-field-type` for list type for consistency
- Rename ambiguous `:name` to `:type-name` in the context of named types
- Add `ID` to default types
