### PR TITLE
Incorporate create-type-system-type into parse transform step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This change
 - Rename ambiguous `:name` to `:type-name` in the context of named types
 - Rename ambiguous `:name` to `:variable-name` in the context of variables
 - Avoid ambiguity between `BooleanValue` and `EnumValue` with ordered choice (using `/` instead of `|`)
+- Reduce code duplication and increase consistency after the parse transform step
 
 ## [0.1.12] - 2016-09-27
 ###Changed

--- a/src/graphql_clj/parser.clj
+++ b/src/graphql_clj/parser.clj
@@ -81,9 +81,25 @@
     (assert fragment-name "fragment name is NULL for fragment-definition!")
     (assoc definition :type :fragment-definition)))
 
-(defn- to-type-system-definition [_ definition]
-  (merge {:type :type-system-definition}
-         definition))
+(def type-system-type->kind
+  {:type      :OBJECT
+   :input     :INPUT_OBJECT
+   :union     :UNION
+   :enum      :ENUM
+   :interface :INTERFACE
+   :directive :DIRECTIVE
+   :schema    :SCHEMA})
+
+(defn- to-type-system-definition [_ {:keys [type-system-type schema-types] :as definition}]
+  (-> (dissoc definition :schema-types)
+      (set/rename-keys {:name              :type-name
+                        :type-fields       :fields
+                        :enum-fields       :fields
+                        :input-type-fields :fields
+                        :directive-on-name :on})
+      (merge schema-types)
+      (assoc :type :type-system-definition
+             :kind (get type-system-type->kind type-system-type))))
 
 (defn- parse-int    [_ v] (Integer/parseInt v))
 (defn- parse-double [_ v] (Double. v))

--- a/test/graphql_clj/parser_test.clj
+++ b/test/graphql_clj/parser_test.clj
@@ -452,12 +452,12 @@ type SearchQuery {
 
 (deftest kv-pairs
   (testing "we can convert type-fields to a map"
-    (is (= (-> (parse type-fields-kv-example) :type-system-definitions first :type-fields)
+    (is (= (-> (parse type-fields-kv-example) :type-system-definitions first :fields)
            {"world" {:arguments  {"flag" {:default-value true :type-name "Boolean"}}
                      :type-name "String" :required true}
             "this" {:type-name "Int"}})))
   (testing "we can convert input-type-fields to a map"
-    (is (= (-> (parse input-type-fields-kv-example) :type-system-definitions first :input-type-fields)
+    (is (= (-> (parse input-type-fields-kv-example) :type-system-definitions first :fields)
            {"world" {:type-name "String" :required true}
             "this"  {:type-name "Int"}})))
   (testing "we can convert variables to a map"


### PR DESCRIPTION
Reduce code duplication and increase consistency after the parse transform step.
