### PR TITLE
Return errors under :errors key

### DIFF
--- a/src/graphql_clj/executor.clj
+++ b/src/graphql_clj/executor.clj
@@ -243,12 +243,12 @@
          schema-resolver-fn (resolver/create-resolver-fn schema resolver-fn)]
      (cond
        (insta/failure? schema) (gerror/throw-error (format "Schema is invalid (%s)." schema))
-       (insta/failure? parsed-document) {:error (parser/parse-error parsed-document)}
+       (insta/failure? parsed-document) {:errors [(parser/parse-error parsed-document)]}
        :else (try
                (execute-document context schema schema-resolver-fn parsed-document variables)
                (catch Exception e
                  (if-let [error (ex-data e)]
-                   {:error [error]}
+                   {:errors [error]}
                    (throw e)))))))
   ([context schema resolver-fn ^String statement]
    (execute context schema resolver-fn statement nil)))

--- a/test/graphql_clj/executor_test.clj
+++ b/test/graphql_clj/executor_test.clj
@@ -67,9 +67,9 @@ schema {
   (testing "test parse error execution"
     (let [query "quer {user}"
           result (execute nil simple-user-schema nil query)]
-      (is (not (nil? (:error result))))
-      (is (= 1 (get-in result [:error :column])))
-      (is (= 1 (get-in result [:error :line]))))))
+      (is (not (nil? (:errors result))))
+      (is (= 1 (get-in result [:errors 0 :column])))
+      (is (= 1 (get-in result [:errors 0 :line]))))))
 
 (deftest test-simple-execution
   (testing "test simple execution"


### PR DESCRIPTION
According to http://graphql.org/learn/serving-over-http/#response any errors should be returned under `:errors` key. This patch changes `:error` -> `:errors`.
