### PR TITLE
Preliminary version of validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. This change
 - Fix `:ListType` parsing
 - Remove `:enum-value` wrapping key for enum values passed as arguments
 - Remove `{:selection { :field }}` wrappers for `:selection-set`
+- Preliminary implementation of validation
 
 ## [0.1.12] - 2016-09-27
 ###Changed

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The implementation of the library follow closely to the GraphQL Draft RFC Specif
 - [ ] Directives
 - [x] Testing
     * [ ] Use clojure.spec to generate test resolver automatically
-- [ ] Schema validation
-- [ ] Query validation
+- [ ] Schema validation, IN PROGRESS__
+- [ ] Query validation, IN PROGRESS__
 - [X] Arguments validation
     * [ ] Argument Coerce
 - [X] Variables validation

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,10 @@
   :url "https://github.com/tendant/graphql-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha12"]
                  [instaparse "1.4.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]
-                 [camel-snake-kebab "0.4.0"]]
+                 [camel-snake-kebab "0.4.0"]
+                 [zip-visit "1.1.0"]]
   :profiles {:dev {:dependencies [[io.forward/yaml "1.0.3"]
                                   [rhizome "0.2.7"]]}})

--- a/src/graphql_clj/parser.clj
+++ b/src/graphql_clj/parser.clj
@@ -41,6 +41,7 @@
 
 (defn- to-operation-definition [_ & args]
   (merge {:section        :operation-definitions
+          :node-type      :operation-definition
           :operation-type {:type "query"}}                  ; default operation as query
          (into {} args)))
 
@@ -67,14 +68,13 @@
       (assoc :kind (get node-type->kind (:node-type definition)))))
 
 (def ^:private transformations
-  "Map from transformation functions to tree tags.
-   This map gets rendered into the format expected by instaparse, e.g.: {:TreeTag fn}
-   Use :k to specify non-standard names for the first argument to the relevant transformation function"
+  "Map from transformation functions to applicable tree tags.
+   This map gets rendered into the format expected by instaparse, e.g.: {:TreeTag fn}"
   {to-ident                  #{:Definition :SchemaType :DirectiveName :ArgumentValue :ListValue :TypeFieldType :Type :Selection :EnumValue}
    to-document               #{:Document}
    to-operation-definition   #{:OperationDefinition}
    to-map                    #{:OperationType :QueryType :MutationType :DirectiveOnName :Implements}
-   to-val                    #{:Name :Value :TypeCondition :TypeFieldArgumentDefault :ListType}
+   to-val                    #{:Name :Value :TypeCondition :TypeFieldArgumentDefault}
    unwrap-name               #{:TypeName :ArgumentName :FieldName :VariableName}
    to-type                   #{:Query :Mutation}
    to-enum-type              #{:EnumTypeInt}
@@ -89,7 +89,7 @@
    add-required              #{:TypeFieldTypeRequired :NonNullType}
    to-type-names             #{:TypeNames :UnionTypeNames}
    to-one-or-more            #{:OneOrMoreValue}
-   to-list                   #{:ListTypeName}
+   to-list                   #{:ListTypeName :ListType}
    args->map                 #{:EnumType :ObjectField :FragmentName :FragmentType :Alias :SchemaTypes}
    to-object-value           #{:ObjectValue}
    to-default-value          #{:DefaultValue}})

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -1,0 +1,108 @@
+(ns graphql-clj.spec
+  (:require [clojure.spec :as s]
+            [clojure.string :as str]
+            [zip.visit :as zv]))
+
+(defn- named-spec
+  "Given an unqualified string, return a registered spec identifier (namespaced keyword)"
+  [type-name]
+  (keyword "graphql-clj.spec" type-name))
+
+(defn- type-names->args [type-names]
+  (mapcat #(vector % %) type-names))
+
+(defn- register-idempotent
+  ([spec-name pred]
+   (cond (keyword? spec-name) spec-name
+         (string? spec-name)  (eval (list 'clojure.spec/def (named-spec spec-name) pred))
+         :else                pred))
+  ([spec-name pred required]
+   (if required
+     (register-idempotent spec-name pred)
+     (register-idempotent (if (keyword? pred) (str (name pred) "*") spec-name) (s/nilable pred))))) ;; TODO inconsistent treatment for scalars with trailing * missing
+
+(defn path->name
+  ([path] (str/join "-" path))
+  ([node-type path] (path->name (cons node-type path))))
+
+(defn- field->spec [{:keys [spec required v/path]}] ;; TODO rethink required
+  (named-spec (path->name path)))
+
+(defn- to-keys [fields]
+  (list 'clojure.spec/keys :opt (map field->spec fields)))
+
+(defmulti spec-for
+  (fn [{:keys [node-type type-name kind]}]
+    (or node-type type-name kind)))
+
+(register-idempotent "Int" int? false)
+(register-idempotent "Int" int? true)
+(register-idempotent "Float" double? false)
+(register-idempotent "Float" double? true)
+(register-idempotent "String" string? false)
+(register-idempotent "String" string? true)
+(register-idempotent "Boolean" boolean? false)
+(register-idempotent "Boolean" boolean? true)
+(register-idempotent "ID" string? false)
+(register-idempotent "ID" string? true)
+
+(defn- extension-type [{:keys [type-name fields type-implements]}]
+  (let [ext-spec (register-idempotent (str type-name "-EXT") (to-keys fields))
+        implements-specs (map named-spec (or (:type-names type-implements) []))
+        type-names (conj implements-specs ext-spec)]
+    (register-idempotent type-name (cons 'clojure.spec/or (type-names->args type-names)))))
+
+(defn- base-type [{:keys [type-name fields]}]
+  (register-idempotent type-name (to-keys fields)))
+
+(defmethod spec-for :type-definition [{:keys [type-implements] :as type-def}] ;; TODO arguments, default-values
+  (if-not (empty? (:type-names type-implements))
+    (extension-type type-def)
+    (base-type type-def)))
+
+(defmethod spec-for :variable-definition [{:keys [variable-name type-name]}]
+  (register-idempotent (str "var-" variable-name) (named-spec type-name))) ;; TODO var uses
+
+(defmethod spec-for :input-definition [{:keys [type-name fields]}]
+  (register-idempotent type-name (to-keys fields)))
+
+(defmethod spec-for :union-definition [{:keys [type-name type-names]}]
+  (register-idempotent type-name (cons 'clojure.spec/or (->> type-names (map named-spec) type-names->args))))
+
+(defmethod spec-for :enum-definition [{:keys [type-name fields]}]
+  (register-idempotent type-name (set (map :name fields))))
+
+(defmethod spec-for :interface-definition [{:keys [type-name fields]}]                   ;; TODO arguments, default-values
+  (register-idempotent type-name (to-keys fields)))
+
+(defmethod spec-for :directive-definition [type-def])                  ;; TODO predicate spec
+(defmethod spec-for :schema-definition [type-def])                     ;; TODO predicate spec
+
+(defmethod spec-for :list [{:keys [inner-type v/path] :as type-def}]
+  (register-idempotent (path->name path) (list 'clojure.spec/coll-of (named-spec (:type-name inner-type))))) ;; TODO required
+
+(defn- register-type-field [path type-name]
+  (register-idempotent (path->name path) (named-spec type-name)))
+
+(defmethod spec-for :type-field [{:keys [v/path type-name]}]
+  (register-type-field path type-name))
+
+(defmethod spec-for :input-type-field [{:keys [v/path type-name]}]
+  (register-type-field path type-name))
+
+(defmethod spec-for :field [{:keys [v/path]}]
+  (named-spec (path->name path)))
+
+(defmethod spec-for :argument [{:keys [v/path]}]
+  (named-spec (path->name "arg" path)))
+
+(defmethod spec-for :type-field-argument [{:keys [v/path type-name]}]
+  (register-idempotent (path->name "arg" path) (named-spec type-name)))
+
+(defmethod spec-for :default [{:keys [node-type type-name] :as node}]
+  nil)
+
+(zv/defvisitor add-spec :pre [n s]
+  (when (map? n)
+    (when-let [spec (spec-for n)]
+      {:node (assoc n :spec spec)})))

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -1,0 +1,19 @@
+(ns graphql-clj.validator
+  (:require [graphql-clj.validator.rules.default-values-of-correct-type]
+            [graphql-clj.validator.rules.arguments-of-correct-type]
+            [graphql-clj.visitor :as visitor]
+            [graphql-clj.spec :as spec]))
+
+(def specified-rules
+  (flatten [[spec/add-spec]
+            graphql-clj.validator.rules.default-values-of-correct-type/rules
+            graphql-clj.validator.rules.arguments-of-correct-type/rules]))
+
+;; TODO visit and validate schema and queries using memoization
+
+(defn validate
+  ([schema]
+   (visitor/visit-document schema [spec/add-spec]))
+  ([_schema document]
+    ;; TODO no use for schema?
+   (visitor/visit-document document specified-rules)))       ;; TODO collect state and nodes afterwards

--- a/src/graphql_clj/validator/errors.clj
+++ b/src/graphql_clj/validator/errors.clj
@@ -1,0 +1,7 @@
+(ns graphql-clj.validator.errors)
+
+(defn- conj-error [error errors]
+  (conj (or errors []) {:error error}))
+
+(defn update-errors [ast error]
+  (update ast :errors (partial conj-error error))) ;; TODO add :loc once parse spans are preserved

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -1,0 +1,18 @@
+(ns graphql-clj.validator.rules.arguments-of-correct-type
+  "A GraphQL document is only valid if all field argument literal values are of the type expected by their position."
+  (:require [graphql-clj.validator.errors :as e]
+            [clojure.spec :as s]
+            [zip.visit :as zv]))
+
+(defn- bad-value-error [arg-name type value]
+  (format "Argument '$%s' of type '%s' has invalid value: %s. Reason: %s value expected."
+          arg-name type value type))
+
+(zv/defvisitor bad-value :pre [{:keys [spec variable-name value type-name node-type] :as n} s]
+  (case node-type
+    :argument
+    (when (and spec value (not (s/valid? spec value)))
+      {:state (e/update-errors s (bad-value-error variable-name type-name value))})
+    nil))
+
+(def rules [bad-value])

--- a/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
@@ -1,0 +1,31 @@
+(ns graphql-clj.validator.rules.default-values-of-correct-type
+  "A GraphQL document is only valid if all variable default values are of the type expected by their definition."
+  (:require [clojure.spec :as s]
+            [graphql-clj.validator.errors :as e]
+            [zip.visit :as zv]))
+
+(defn- default-for-required-arg-error [var-name type]
+  (format "Variable '$%s' of type '%s!' is required and will never use the default value. Perhaps you meant to use type '%s'."
+          var-name type type))
+
+(zv/defvisitor default-for-required-field :pre [{:keys [node-type required default-value variable-name type-name] :as n} s]
+  (case node-type
+    :variable-definition
+    (when (and required default-value)
+      {:state (e/update-errors s (default-for-required-arg-error variable-name type-name))})
+    nil))
+
+(defn- bad-value-for-default-error [var-name type default-value]
+  (format "Variable '$%s' of type '%s' has invalid default value: \"%s\". Reason: %s value expected."
+          var-name type default-value type))
+
+(zv/defvisitor bad-value-for-default :pre [{:keys [node-type spec variable-name default-value type-name] :as n} s]
+  (case node-type
+    :variable-definition
+    (when (and spec default-value (not (s/valid? spec default-value)))
+      {:state (e/update-errors s (bad-value-for-default-error variable-name type-name default-value))})
+    nil))
+
+(def rules
+  [default-for-required-field
+   bad-value-for-default])

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -1,0 +1,80 @@
+(ns graphql-clj.visitor
+  (:require [clojure.zip :as z]
+            [zip.visit :as zv]))
+
+;; Mappings
+
+(def ^:private node-type->children
+  "Mapping from a node type to a set of keys that contain "
+  {:type-definition        #{:fields}
+   :type-field             #{:arguments}
+   :field                  #{:arguments :selection-set}
+   :operation-definition   #{:selection-set :variable-definitions}
+   :operations-definitions #{:operation-definition}
+   :interface-definition   #{:fields}
+   :input-definition       #{:fields}})
+
+(def ^:private node-type->label-key
+  {:type-definition      [:type-name]
+   :type-field           [:field-name]
+   :field                [:field-name]
+   :argument             [:argument-name]
+   :variable-definition  [:variable-name]
+   :interface-definition [:type-name]
+   :enum-definition      [:type-name]
+   :type-field-argument  [:argument-name]
+   :list                 [:field-name :argument-name]
+   :input-type-field     [:field-name]
+   :input-definition     [:type-name]})
+
+;; Zipper
+
+(def ^:private keys-with-children
+  (reduce (fn [acc [_ v]] (into acc v)) #{} node-type->children))
+
+(def ^:private has-children?
+  (apply some-fn keys-with-children))
+
+(def ^:private node-type->label-key-fn
+  (->> (map (fn [[k v]] [k (apply some-fn v)]) node-type->label-key) (into {})))
+
+(defn- branch? [node]
+  (or (vector? node) (and (map? node) (has-children? node))))
+
+(defn- node->label [{:keys [node-type] :as node}]
+  (when-let [label-fn (get node-type->label-key-fn node-type)]
+    (label-fn node)))
+
+(defn- parent-path [parent]
+  (or (:v/path parent) (if-let [label (node->label parent)] [label] [])))
+
+(defn- add-path [parentk parent child]
+  (assoc child :v/parentk parentk
+               :v/path (conj (parent-path parent) (node->label child))))
+
+(defn- children-w-path [node f]
+  (->> (f node) (map (partial add-path f node))))
+
+(defn- children [node]
+  (cond (vector? node) node
+        (map? node) (->> (get node-type->children (:node-type node))
+                         (mapcat (partial children-w-path node)))))
+
+(defn- make-node [node children]
+  (if (map? node)
+    (merge node (group-by :v/parentk children))
+    children))
+
+(def ^:private zipper (partial z/zipper branch? children make-node))
+
+;; Public API
+
+(defn visit
+  "Returns a map with 2 keys: :node contains the visited tree, :state contains the accumulated state"
+  [ast visitor-fns]
+  (zv/visit (zipper ast) nil visitor-fns))
+
+(def document-sections [:type-system-definitions :fragment-definitions :operation-definitions])
+
+(defn visit-document [document visitor-fns]
+  (reduce #(update %1 %2 visit visitor-fns) document document-sections))

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -67,14 +67,16 @@
 
 (def ^:private zipper (partial z/zipper branch? children make-node))
 
-;; Public API
-
-(defn visit
+(defn- visit
   "Returns a map with 2 keys: :node contains the visited tree, :state contains the accumulated state"
   [ast visitor-fns]
   (zv/visit (zipper ast) nil visitor-fns))
 
-(def document-sections [:type-system-definitions :fragment-definitions :operation-definitions])
+(def ^:private document-sections [:type-system-definitions
+                                  :fragment-definitions
+                                  :operation-definitions])
+
+;; Public API
 
 (defn visit-document [document visitor-fns]
   (reduce #(update %1 %2 visit visitor-fns) document document-sections))

--- a/test/graphql_clj/spec_test.clj
+++ b/test/graphql_clj/spec_test.clj
@@ -1,0 +1,22 @@
+(ns graphql-clj.spec-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec :as s]
+            [clojure.data]
+            [graphql-clj.spec :as spec]
+            [graphql-clj.visitor-test :as vt]
+            [graphql-clj.visitor :as visitor]))
+
+(visitor/visit-document vt/document [spec/add-spec])
+
+(deftest spec-validation
+  (testing "pre-order visit and add a spec to relevant nodes"
+    (is (s/valid? :graphql-clj.spec/Person-name "Name"))
+    (is (not (s/valid? :graphql-clj.spec/Person-name 42)))
+    (is (s/valid? :graphql-clj.spec/Person-age 42))
+    (is (not (s/valid? :graphql-clj.spec/Person-age "42")))
+    (is (s/valid? :graphql-clj.spec/Person-picture 13.37))
+    (is (not (s/valid? :graphql-clj.spec/Person-picture "13.37")))
+    (is (s/valid? :graphql-clj.spec/Person {"name" "Name" "age" 42 "picture" 13.37}))
+    (is (not (s/valid? :graphql-clj.spec/Person {:graphql-clj.spec/Person-name 42
+                                                 :graphql-clj.spec/Person.age  "42"
+                                                 :graphql-clj.spec/Person-picture "13.37"})))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -1,0 +1,35 @@
+(ns graphql-clj.validator-test
+  (:require [clojure.test :refer :all]
+            [graphql-clj.validator :as validator]
+            [yaml.core :as yaml]
+            [graphql-clj.parser :as parser]
+            [graphql-clj.test-helpers :as th]))
+
+(def schema
+  (-> (parser/parse (slurp "test/scenarios/cats/validation/validation.schema.graphql"))
+      validator/validate))
+
+(assert (not (nil? schema)) "No schema found!")
+
+(defn validate-test-case [{:keys [parsed] :as test-case}]
+  (assoc test-case :validated (validator/validate schema parsed)))
+
+(def cats
+  (->> [(get (yaml/from-file "test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml") "tests")
+        (get (yaml/from-file "test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml") "tests")]
+       flatten
+       (map th/parse-test-case)
+       (map validate-test-case)))
+
+(deftest default-values-of-correct-type
+  (testing "default-for-required-field"
+    (let [{:keys [validated expected]} (nth cats 3)]
+      (is (= (count expected) (-> validated :operation-definitions :state :errors count)))))
+  (testing "bad-value-for-default"
+    (let [{:keys [validated expected]} (nth cats 4)]
+      (is (= (count expected) (->> validated :operation-definitions :state :errors count))))))
+
+(deftest arguments-of-correct-type
+  (testing "bad-value"
+    (let [{:keys [validated expected]} (nth cats 6)]
+      (is (= (count expected) (->> validated :operation-definitions :state :errors count))))))

--- a/test/graphql_clj/visitor_test.clj
+++ b/test/graphql_clj/visitor_test.clj
@@ -1,0 +1,181 @@
+(ns graphql-clj.visitor-test
+  (:require [clojure.test :refer :all]
+            [graphql-clj.visitor :as visitor]
+            [graphql-clj.spec :as spec]
+            [clojure.data]))
+
+(def document
+  {:type-system-definitions
+   [{:node-type :type-definition
+     :type-name "Person"
+     :section   :type-system-definitions
+     :fields    [{:node-type :type-field :field-name "name" :type-name "String"}
+                 {:node-type :type-field :field-name "age" :type-name "Int"}
+                 {:node-type :type-field :field-name "picture" :type-name "Float"}]
+     :kind      :OBJECT}]
+   :operation-definitions
+   [{:section        :operation-definitions
+     :node-type      :operation-definition
+     :operation-type {:type "query" :name "NullableValues"}
+     :selection-set  [{:node-type     :field
+                       :field-name    "Person"
+                       :arguments     [{:node-type :argument :argument-name "id" :value 4}]
+                       :selection-set [{:node-type :field :field-name "id"}
+                                       {:node-type :field :field-name "name"}
+                                       {:node-type  :field
+                                        :field-name "profilePic"
+                                        :arguments  [{:node-type :argument :argument-name "width" :value 100}
+                                                     {:node-type     :argument
+                                                      :argument-name "height"
+                                                      :value         50.0}]}]}]}]})
+
+(def visited-document
+  {:type-system-definitions
+                         {:node
+                                 [{:node-type :type-definition
+                                   :type-name "Person"
+                                   :section   :type-system-definitions
+                                   :fields
+                                              [{:node-type  :type-field
+                                                :field-name "name"
+                                                :type-name  "String"
+                                                :v/parentk  :fields
+                                                :v/path     ["Person" "name"]}
+                                               {:node-type  :type-field
+                                                :field-name "age"
+                                                :type-name  "Int"
+                                                :v/parentk  :fields
+                                                :v/path     ["Person" "age"]}
+                                               {:node-type  :type-field
+                                                :field-name "picture"
+                                                :type-name  "Float"
+                                                :v/parentk  :fields
+                                                :v/path     ["Person" "picture"]}]
+                                   :kind      :OBJECT}]
+                          :state nil}
+   :operation-definitions
+                         {:node
+                                 [{:section        :operation-definitions
+                                   :node-type      :operation-definition
+                                   :operation-type {:type "query" :name "NullableValues"}
+                                   :selection-set
+                                                   [{:node-type  :field
+                                                     :field-name "Person"
+                                                     :arguments
+                                                                 [{:node-type     :argument
+                                                                   :argument-name "id"
+                                                                   :value         4
+                                                                   :v/parentk     :arguments
+                                                                   :v/path        ["Person" "id"]}]
+                                                     :selection-set
+                                                                 [{:node-type  :field
+                                                                   :field-name "id"
+                                                                   :v/parentk  :selection-set
+                                                                   :v/path     ["Person" "id"]}
+                                                                  {:node-type  :field
+                                                                   :field-name "name"
+                                                                   :v/parentk  :selection-set
+                                                                   :v/path     ["Person" "name"]}
+                                                                  {:node-type  :field
+                                                                   :field-name "profilePic"
+                                                                   :arguments
+                                                                               [{:node-type     :argument
+                                                                                 :argument-name "width"
+                                                                                 :value         100
+                                                                                 :v/parentk     :arguments
+                                                                                 :v/path        ["Person" "profilePic" "width"]}
+                                                                                {:node-type     :argument
+                                                                                 :argument-name "height"
+                                                                                 :value         50.0
+                                                                                 :v/parentk     :arguments
+                                                                                 :v/path        ["Person" "profilePic" "height"]}]
+                                                                   :v/parentk  :selection-set
+                                                                   :v/path     ["Person" "profilePic"]}]
+                                                     :v/parentk  :selection-set
+                                                     :v/path     ["Person"]}]}]
+                          :state nil}
+   :fragment-definitions {:node nil :state nil}})
+
+(def visited-spec-document
+  {:type-system-definitions
+                         {:node
+                                 [{:node-type :type-definition
+                                   :type-name "Person"
+                                   :section   :type-system-definitions
+                                   :fields
+                                              [{:node-type  :type-field
+                                                :field-name "name"
+                                                :type-name  "String"
+                                                :v/parentk  :fields
+                                                :v/path     ["Person" "name"]
+                                                :spec       :graphql-clj.spec/Person-name}
+                                               {:node-type  :type-field
+                                                :field-name "age"
+                                                :type-name  "Int"
+                                                :v/parentk  :fields
+                                                :v/path     ["Person" "age"]
+                                                :spec       :graphql-clj.spec/Person-age}
+                                               {:node-type  :type-field
+                                                :field-name "picture"
+                                                :type-name  "Float"
+                                                :v/parentk  :fields
+                                                :v/path     ["Person" "picture"]
+                                                :spec       :graphql-clj.spec/Person-picture}]
+                                   :kind      :OBJECT
+                                   :spec      :graphql-clj.spec/Person}]
+                          :state nil}
+   :operation-definitions
+                         {:node
+                                 [{:section        :operation-definitions
+                                   :node-type      :operation-definition
+                                   :operation-type {:type "query" :name "NullableValues"}
+                                   :selection-set
+                                                   [{:node-type  :field
+                                                     :field-name "Person"
+                                                     :arguments
+                                                                 [{:node-type     :argument
+                                                                   :argument-name "id"
+                                                                   :value         4
+                                                                   :v/parentk     :arguments
+                                                                   :v/path        ["Person" "id"]
+                                                                   :spec          :graphql-clj.spec/arg-Person-id}]
+                                                     :selection-set
+                                                                 [{:node-type  :field
+                                                                   :field-name "id"
+                                                                   :v/parentk  :selection-set
+                                                                   :v/path     ["Person" "id"]
+                                                                   :spec       :graphql-clj.spec/Person-id}
+                                                                  {:node-type  :field
+                                                                   :field-name "name"
+                                                                   :v/parentk  :selection-set
+                                                                   :v/path     ["Person" "name"]
+                                                                   :spec       :graphql-clj.spec/Person-name}
+                                                                  {:node-type  :field
+                                                                   :field-name "profilePic"
+                                                                   :arguments
+                                                                               [{:node-type     :argument
+                                                                                 :argument-name "width"
+                                                                                 :value         100
+                                                                                 :v/parentk     :arguments
+                                                                                 :v/path        ["Person" "profilePic" "width"]
+                                                                                 :spec          :graphql-clj.spec/arg-Person-profilePic-width}
+                                                                                {:node-type     :argument
+                                                                                 :argument-name "height"
+                                                                                 :value         50.0
+                                                                                 :v/parentk     :arguments
+                                                                                 :v/path        ["Person" "profilePic" "height"]
+                                                                                 :spec          :graphql-clj.spec/arg-Person-profilePic-height}]
+                                                                   :v/parentk  :selection-set
+                                                                   :v/path     ["Person" "profilePic"]
+                                                                   :spec       :graphql-clj.spec/Person-profilePic}]
+                                                     :v/parentk  :selection-set
+                                                     :v/path     ["Person"]
+                                                     :spec       :graphql-clj.spec/Person}]}]
+                          :state nil}
+   :fragment-definitions {:node nil :state nil}})
+
+(deftest adding-path
+  (testing "DFS traversal adding the path as we go"
+    (is (= visited-document (visitor/visit-document document []))))
+  (testing "pre-order visit and add a spec to relevant nodes"
+    (is (= visited-spec-document (visitor/visit-document document [spec/add-spec])))))

--- a/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
@@ -1,0 +1,16 @@
+scenario: "Validate: Argument values of correct type"
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: argument type mismatch
+    given:
+      query: |
+        query BadArgumentValue {
+          Dog { name(surname: "notaboolean") }
+        }
+    when:
+      validate: [ArgumentsOfCorrectType]
+    then:
+      - error-count: 1
+      - error: "Argument 'surname' of type 'Boolean' has an invalid value: 'notaboolean'. Reason: Boolean value expected."
+        loc: {line: 1, column: 30}


### PR DESCRIPTION
Very preliminary and partial implementation of validation, mainly for early feedback:
- Depends on `clojure.spec`, so requires `clojure 1.9.0-alpha2`
- Use global named specs that match the nested structure of the tree
- Use zippers and zip-visit to implement the visitor pattern (mirrors structure of graphql-js reference implementation)
- Make handling lists of scalars more consistent

There are a number of TODO's in the code.  
