### PR TITLE
Bugfixes and state for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The implementation of the library follow closely to the GraphQL Draft RFC Specif
 - [ ] Directives
 - [x] Testing
     * [ ] Use clojure.spec to generate test resolver automatically
-- [ ] Schema validation, IN PROGRESS__
-- [ ] Query validation, IN PROGRESS__
+- [ ] __Schema validation, IN PROGRESS__
+- [ ] __Query validation, IN PROGRESS__
 - [X] Arguments validation
     * [ ] Argument Coerce
 - [X] Variables validation

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -55,7 +55,7 @@
     (register-idempotent (path->name path) (cons 'clojure.spec/or (type-names->args type-names)))))
 
 (defn- base-type [{:keys [v/path fields]}]
-  (register-idempotent (path->name path) (to-keys fields))) ;; TODO: on a pre-order traversal fields don't have paths
+  (register-idempotent (path->name path) (to-keys fields)))
 
 (defmethod spec-for :type-definition [{:keys [type-implements v/path] :as type-def}]
   (when (> (count path) 0)
@@ -77,9 +77,6 @@
 
 (defmethod spec-for :interface-definition [{:keys [type-name fields]}]
   (register-idempotent type-name (to-keys fields)))
-
-(defmethod spec-for :directive-definition [type-def])                  ;; TODO predicate spec
-(defmethod spec-for :schema-definition [type-def])                     ;; TODO predicate spec
 
 (defmethod spec-for :list [{:keys [inner-type v/path]}] ;; TODO ignores required
   (register-idempotent (path->name path) (list 'clojure.spec/coll-of (named-spec (:type-name inner-type)))))

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -1,7 +1,7 @@
 (ns graphql-clj.spec
   (:require [clojure.spec :as s]
             [clojure.string :as str]
-            [zip.visit :as zv]))
+            [graphql-clj.visitor :as v]))
 
 (defn- named-spec
   "Given an unqualified string, return a registered spec identifier (namespaced keyword)"
@@ -104,6 +104,6 @@
 
 (defmethod spec-for :default [_])
 
-(zv/defvisitor add-spec :post [n s]
-  (when-let [spec (and (map? n) (spec-for n))]
+(v/defmapvisitor add-spec :post [n s]
+  (when-let [spec (spec-for n)]
     {:node (assoc n :spec spec)}))

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -9,6 +9,29 @@
    "Boolean" {:type-name "Boolean" :kind :SCALAR}
    "ID"      {:type-name "ID"      :kind :SCALAR}})
 
+(defn query-root-name
+  "Given a parsed schema document, return the query-root-name (default is Query)"
+  [parsed-schema]                           ;; TODO deduplicate, TODO test
+  (or (some->> parsed-schema
+               :type-system-definitions
+               (filter #(= :schema-definition (:node-type %)))
+               first
+               :query-type
+               :name) "Query"))
+
+(defn query-root-fields
+  "Given a parsed schema document, return [query-root-name {root-field Type}]
+   When validating queries, we need to know the types of the root fields to map to the same specs
+   that we registered when parsing the schema."
+  [root-query-name parsed-schema]                           ;; TODO deduplicate, TODO test
+  (some->> parsed-schema
+           :type-system-definitions
+           (filter #(= (:type-name %) root-query-name))
+           first
+           :fields
+           (map (juxt :field-name :type-name))
+           (into {})))
+
 (defn create-schema
   "Create schema definition from parsed & transformed type system definition."
   ([parsed-schema introspection-schema]

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -33,10 +33,6 @@
   ([parsed-schema]
    (create-schema parsed-schema nil)))
 
-(defn inject-introspection-schema [schema introspection-schema]
-  "Combine schema definition with introspection schema"
-  (merge-with merge schema introspection-schema))
-
 (defn get-enum-in-schema [schema enum-name]
   "Get enum definition for given 'enum-name' from provided 'schema'."
   (if (nil? enum-name)

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -5,15 +5,12 @@
             [graphql-clj.spec :as spec]))
 
 (def specified-rules
-  (flatten [[spec/add-spec]
-            graphql-clj.validator.rules.default-values-of-correct-type/rules
+  (flatten [graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules]))
-
-;; TODO visit and validate schema and queries using memoization
 
 (defn validate
   ([schema]
    (visitor/visit-document schema [spec/add-spec]))
-  ([_schema document]
-    ;; TODO no use for schema?
-   (visitor/visit-document document specified-rules)))       ;; TODO collect state and nodes afterwards
+  ([schema document]
+   (let [document' (:document (visitor/visit-document document (visitor/query-root-mapping (:document schema)) [spec/add-spec]))]
+     (visitor/visit-document document' specified-rules))))

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -5,12 +5,14 @@
             [graphql-clj.spec :as spec]))
 
 (def specified-rules
-  (flatten [graphql-clj.validator.rules.default-values-of-correct-type/rules
+  (flatten [[spec/add-spec]
+            graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules]))
 
-(defn validate
-  ([schema]
-   (visitor/visit-document schema [spec/add-spec]))
-  ([schema document]
-   (let [document' (:document (visitor/visit-document document (visitor/query-root-mapping (:document schema)) [spec/add-spec]))]
-     (visitor/visit-document document' specified-rules))))
+(defn validate-schema [schema]                              ;; TODO inject introspection schema?
+  (let [s (visitor/initial-state schema)
+        validated-schema (visitor/visit-document schema s specified-rules)]
+    (assoc s :schema (:document validated-schema))))
+
+(defn validate-statement [document schema]
+  (visitor/visit-document document schema specified-rules))

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -8,12 +8,11 @@
   (format "Argument '$%s' of type '%s' has invalid value: %s. Reason: %s value expected."
           arg-name type value type))
 
-(defmapvisitor bad-value :post [n s]
-  (when-let [{:keys [spec variable-name value type-name node-type]} (and (map? n) n)]
-    (case node-type
-      :argument
-      (when (and spec value (not (s/valid? spec value)))
-        {:state (e/update-errors s (bad-value-error variable-name type-name value))})
-      nil)))
+(defmapvisitor bad-value :post [{:keys [spec variable-name value type-name node-type]} s]
+  (case node-type
+    :argument
+    (when (and spec value (not (s/valid? spec value)))
+      {:state (e/update-errors s (bad-value-error variable-name type-name value))})
+    nil))
 
 (def rules [bad-value])

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -1,18 +1,19 @@
 (ns graphql-clj.validator.rules.arguments-of-correct-type
   "A GraphQL document is only valid if all field argument literal values are of the type expected by their position."
   (:require [graphql-clj.validator.errors :as e]
-            [clojure.spec :as s]
-            [zip.visit :as zv]))
+            [graphql-clj.visitor :refer [defmapvisitor]]
+            [clojure.spec :as s]))
 
 (defn- bad-value-error [arg-name type value]
   (format "Argument '$%s' of type '%s' has invalid value: %s. Reason: %s value expected."
           arg-name type value type))
 
-(zv/defvisitor bad-value :pre [{:keys [spec variable-name value type-name node-type] :as n} s]
-  (case node-type
-    :argument
-    (when (and spec value (not (s/valid? spec value)))
-      {:state (e/update-errors s (bad-value-error variable-name type-name value))})
-    nil))
+(defmapvisitor bad-value :post [n s]
+  (when-let [{:keys [spec variable-name value type-name node-type]} (and (map? n) n)]
+    (case node-type
+      :argument
+      (when (and spec value (not (s/valid? spec value)))
+        {:state (e/update-errors s (bad-value-error variable-name type-name value))})
+      nil)))
 
 (def rules [bad-value])

--- a/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
@@ -8,25 +8,23 @@
   (format "Variable '$%s' of type '%s!' is required and will never use the default value. Perhaps you meant to use type '%s'."
           var-name type type))
 
-(defmapvisitor default-for-required-field :post [n s]
-  (when-let [{:keys [node-type required default-value variable-name type-name]} (and (map? n) n)]
-    (case node-type
-      :variable-definition
-      (when (and required default-value)
-        {:state (e/update-errors s (default-for-required-arg-error variable-name type-name))})
-      nil)))
+(defmapvisitor default-for-required-field :post [{:keys [node-type required default-value variable-name type-name]} s]
+  (case node-type
+    :variable-definition
+    (when (and required default-value)
+      {:state (e/update-errors s (default-for-required-arg-error variable-name type-name))})
+    nil))
 
 (defn- bad-value-for-default-error [var-name type default-value]
   (format "Variable '$%s' of type '%s' has invalid default value: \"%s\". Reason: %s value expected."
           var-name type default-value type))
 
-(defmapvisitor bad-value-for-default :post [n s]
-  (when-let [{:keys [node-type spec variable-name default-value type-name]} (and (map? n) n)]
-    (case node-type
-      :variable-definition
-      (when (and spec default-value (not (s/valid? spec default-value)))
-        {:state (e/update-errors s (bad-value-for-default-error variable-name type-name default-value))})
-      nil)))
+(defmapvisitor bad-value-for-default :post [{:keys [node-type spec variable-name default-value type-name]} s]
+  (case node-type
+    :variable-definition
+    (when (and spec default-value (not (s/valid? spec default-value)))
+      {:state (e/update-errors s (bad-value-for-default-error variable-name type-name default-value))})
+    nil))
 
 (def rules
   [default-for-required-field

--- a/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
@@ -2,29 +2,31 @@
   "A GraphQL document is only valid if all variable default values are of the type expected by their definition."
   (:require [clojure.spec :as s]
             [graphql-clj.validator.errors :as e]
-            [zip.visit :as zv]))
+            [graphql-clj.visitor :refer [defmapvisitor]]))
 
 (defn- default-for-required-arg-error [var-name type]
   (format "Variable '$%s' of type '%s!' is required and will never use the default value. Perhaps you meant to use type '%s'."
           var-name type type))
 
-(zv/defvisitor default-for-required-field :pre [{:keys [node-type required default-value variable-name type-name] :as n} s]
-  (case node-type
-    :variable-definition
-    (when (and required default-value)
-      {:state (e/update-errors s (default-for-required-arg-error variable-name type-name))})
-    nil))
+(defmapvisitor default-for-required-field :post [n s]
+  (when-let [{:keys [node-type required default-value variable-name type-name]} (and (map? n) n)]
+    (case node-type
+      :variable-definition
+      (when (and required default-value)
+        {:state (e/update-errors s (default-for-required-arg-error variable-name type-name))})
+      nil)))
 
 (defn- bad-value-for-default-error [var-name type default-value]
   (format "Variable '$%s' of type '%s' has invalid default value: \"%s\". Reason: %s value expected."
           var-name type default-value type))
 
-(zv/defvisitor bad-value-for-default :pre [{:keys [node-type spec variable-name default-value type-name] :as n} s]
-  (case node-type
-    :variable-definition
-    (when (and spec default-value (not (s/valid? spec default-value)))
-      {:state (e/update-errors s (bad-value-for-default-error variable-name type-name default-value))})
-    nil))
+(defmapvisitor bad-value-for-default :post [n s]
+  (when-let [{:keys [node-type spec variable-name default-value type-name]} (and (map? n) n)]
+    (case node-type
+      :variable-definition
+      (when (and spec default-value (not (s/valid? spec default-value)))
+        {:state (e/update-errors s (bad-value-for-default-error variable-name type-name default-value))})
+      nil)))
 
 (def rules
   [default-for-required-field

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -12,7 +12,8 @@
    :operation-definition   #{:selection-set :variable-definitions}
    :operations-definitions #{:operation-definition}
    :interface-definition   #{:fields}
-   :input-definition       #{:fields}})
+   :input-definition       #{:fields}
+   :query-root             #{:children}})
 
 (def ^:private node-type->label-key
   {:type-definition      [:type-name]
@@ -41,42 +42,80 @@
 (defn- branch? [node]
   (or (vector? node) (and (map? node) (has-children? node))))
 
-(defn- node->label [{:keys [node-type] :as node}]
+(defn- node->label [query-root-mapping {:keys [node-type] :as node}]
   (when-let [label-fn (get node-type->label-key-fn node-type)]
-    (label-fn node)))
+    (let [label (label-fn node)
+          label (get (last query-root-mapping) label label)]
+      (when-not (= label (first query-root-mapping))
+        label))))
 
-(defn- parent-path [parent]
-  (or (:v/path parent) (if-let [label (node->label parent)] [label] [])))
+(defn- parent-path [query-root-mapping parent]
+  (or (:v/path parent) (if-let [label (node->label query-root-mapping parent)] [label] [])))
 
-(defn- add-path [parentk parent child]
+(defn conj-child-path [query-root-mapping child parent-path]
+  (let [child-label (node->label query-root-mapping child)]
+    (if (and child-label (not= child-label (first parent-path)))
+      (conj parent-path child-label)
+      parent-path)))
+
+(defn- add-path [query-root-mapping parentk parent child]
   (assoc child :v/parentk parentk
-               :v/path (conj (parent-path parent) (node->label child))))
+               :v/path (->> (parent-path query-root-mapping parent)
+                            (conj-child-path query-root-mapping child))))
 
-(defn- children-w-path [node f]
-  (->> (f node) (map (partial add-path f node))))
+(defn- children-w-path [query-root-mapping node f]
+  (->> (f node) (map (partial add-path query-root-mapping f node))))
 
-(defn- children [node]
+(defn- children [query-root-mapping node]
   (cond (vector? node) node
         (map? node) (->> (get node-type->children (:node-type node))
-                         (mapcat (partial children-w-path node)))))
+                         (mapcat (partial children-w-path query-root-mapping node)))))
 
 (defn- make-node [node children]
   (if (map? node)
     (merge node (group-by :v/parentk children))
     children))
 
-(def ^:private zipper (partial z/zipper branch? children make-node))
+(defn- zipper [query-root-mapping ast]
+  (z/zipper branch? (partial children query-root-mapping) make-node ast))
 
 (defn- visit
   "Returns a map with 2 keys: :node contains the visited tree, :state contains the accumulated state"
-  [ast visitor-fns]
-  (zv/visit (zipper ast) nil visitor-fns))
+  [query-root-mapping ast visitor-fns]
+  (zv/visit (zipper query-root-mapping [{:node-type :query-root :children ast}]) {} visitor-fns))
 
 (def ^:private document-sections [:type-system-definitions
                                   :fragment-definitions
                                   :operation-definitions])
 
+(defn- root-query-name [document]                           ;; TODO use pre-existing schema functions
+  (or (some->> document
+               :type-system-definitions
+               (filter #(= :schema-definition (:node-type %)))
+               first
+               :query-type
+               :name) "Query"))
+
+(defn query-root-mapping [document]                        ;; TODO use pre-existing schema functions
+  (let [n (root-query-name document)]
+    [n (some->> document
+                :type-system-definitions
+                (filter #(= (:type-name %) n))
+                first
+                :fields
+                (map (juxt :field-name :type-name))
+                (into {}))]))
+
+(defn- merge-document [document]
+  {:document (into {} (mapv (fn [[k v]] [k (-> v :node first :children)]) document))
+   :state    (into {} (map (fn [[k v]] [k (-> v :state)]) document))})
+
 ;; Public API
 
-(defn visit-document [document visitor-fns]
-  (reduce #(update %1 %2 visit visitor-fns) document document-sections))
+(defn visit-document
+  ([document root-query-mapping visitor-fns]
+   (->> document-sections
+        (reduce #(update %1 %2 (partial visit (or root-query-mapping {})) visitor-fns) document)
+        merge-document))
+  ([document visitor-fns]
+   (visit-document document (query-root-mapping document) visitor-fns)))

--- a/test/graphql_clj/spec_test.clj
+++ b/test/graphql_clj/spec_test.clj
@@ -1,10 +1,9 @@
 (ns graphql-clj.spec-test
   (:require [clojure.test :refer :all]
             [clojure.spec :as s]
-            [clojure.data]
             [graphql-clj.spec :as spec]
-            [graphql-clj.visitor-test :as vt]
-            [graphql-clj.visitor :as visitor]))
+            [graphql-clj.visitor :as visitor]
+            [graphql-clj.visitor-test :as vt]))
 
 (visitor/visit-document vt/document [spec/add-spec])
 
@@ -17,6 +16,9 @@
     (is (s/valid? :graphql-clj.spec/Person-picture 13.37))
     (is (not (s/valid? :graphql-clj.spec/Person-picture "13.37")))
     (is (s/valid? :graphql-clj.spec/Person {"name" "Name" "age" 42 "picture" 13.37}))
+    (is (= (s/describe :graphql-clj.spec/Person) '(keys :opt (:graphql-clj.spec/Person-name
+                                                               :graphql-clj.spec/Person-age
+                                                               :graphql-clj.spec/Person-picture))))
     (is (not (s/valid? :graphql-clj.spec/Person {:graphql-clj.spec/Person-name 42
-                                                 :graphql-clj.spec/Person.age  "42"
+                                                 :graphql-clj.spec/Person-age  "42"
                                                  :graphql-clj.spec/Person-picture "13.37"})))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -24,12 +24,12 @@
 (deftest default-values-of-correct-type
   (testing "default-for-required-field"
     (let [{:keys [validated expected]} (nth cats 3)]
-      (is (= (count expected) (-> validated :operation-definitions :state :errors count)))))
+      (is (= (count expected) (-> validated :state :operation-definitions :errors count)))))
   (testing "bad-value-for-default"
     (let [{:keys [validated expected]} (nth cats 4)]
-      (is (= (count expected) (->> validated :operation-definitions :state :errors count))))))
+      (is (= (count expected) (->> validated :state :operation-definitions :errors count))))))
 
 (deftest arguments-of-correct-type
   (testing "bad-value"
     (let [{:keys [validated expected]} (nth cats 6)]
-      (is (= (count expected) (->> validated :operation-definitions :state :errors count))))))
+      (is (= (count expected) (->> validated :state :operation-definitions :errors count))))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -7,12 +7,12 @@
 
 (def schema
   (-> (parser/parse (slurp "test/scenarios/cats/validation/validation.schema.graphql"))
-      validator/validate))
+      validator/validate-schema))
 
 (assert (not (nil? schema)) "No schema found!")
 
 (defn validate-test-case [{:keys [parsed] :as test-case}]
-  (assoc test-case :validated (validator/validate schema parsed)))
+  (assoc test-case :validated (validator/validate-statement parsed schema)))
 
 (def cats
   (->> [(get (yaml/from-file "test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml") "tests")

--- a/test/graphql_clj/visitor_test.clj
+++ b/test/graphql_clj/visitor_test.clj
@@ -131,7 +131,9 @@
                             :v/path []}]
     :fragment-definitions nil}
    :state
-   {:type-system-definitions {}
+   {:query-root-name "QueryRoot"
+    :query-root-fields {"person" "Person"}
+    :type-system-definitions {}
     :operation-definitions {}
     :fragment-definitions {}}})
 
@@ -240,7 +242,9 @@
                             :v/path []}]
     :fragment-definitions nil}
    :state
-   {:type-system-definitions {}
+   {:query-root-name "QueryRoot"
+    :query-root-fields {"person" "Person"}
+    :type-system-definitions {}
     :operation-definitions {}
     :fragment-definitions {}}} )
 

--- a/test/graphql_clj/visitor_test.clj
+++ b/test/graphql_clj/visitor_test.clj
@@ -6,7 +6,17 @@
 
 (def document
   {:type-system-definitions
-   [{:node-type :type-definition
+   [{:node-type :schema-definition
+     :query-type {:name "QueryRoot"}
+     :section :type-system-definitions
+     :kind :SCHEMA}
+    {:node-type :type-definition
+     :type-name "QueryRoot"
+     :section :type-system-definitions
+     :fields  [{:node-type :type-field :field-name "person" :type-name "Person"
+                :arguments [{:node-type :type-field-argument :argument-name "id" :type-name "Int"}]}]
+     :kind :OBJECT}
+    {:node-type :type-definition
      :type-name "Person"
      :section   :type-system-definitions
      :fields    [{:node-type :type-field :field-name "name" :type-name "String"}
@@ -18,7 +28,7 @@
      :node-type      :operation-definition
      :operation-type {:type "query" :name "NullableValues"}
      :selection-set  [{:node-type     :field
-                       :field-name    "Person"
+                       :field-name    "person"
                        :arguments     [{:node-type :argument :argument-name "id" :value 4}]
                        :selection-set [{:node-type :field :field-name "id"}
                                        {:node-type :field :field-name "name"}
@@ -30,149 +40,209 @@
                                                       :value         50.0}]}]}]}]})
 
 (def visited-document
-  {:type-system-definitions
-                         {:node
-                                 [{:node-type :type-definition
-                                   :type-name "Person"
-                                   :section   :type-system-definitions
-                                   :fields
-                                              [{:node-type  :type-field
-                                                :field-name "name"
-                                                :type-name  "String"
-                                                :v/parentk  :fields
-                                                :v/path     ["Person" "name"]}
-                                               {:node-type  :type-field
-                                                :field-name "age"
-                                                :type-name  "Int"
-                                                :v/parentk  :fields
-                                                :v/path     ["Person" "age"]}
-                                               {:node-type  :type-field
-                                                :field-name "picture"
-                                                :type-name  "Float"
-                                                :v/parentk  :fields
-                                                :v/path     ["Person" "picture"]}]
-                                   :kind      :OBJECT}]
-                          :state nil}
-   :operation-definitions
-                         {:node
-                                 [{:section        :operation-definitions
-                                   :node-type      :operation-definition
-                                   :operation-type {:type "query" :name "NullableValues"}
-                                   :selection-set
-                                                   [{:node-type  :field
-                                                     :field-name "Person"
-                                                     :arguments
-                                                                 [{:node-type     :argument
-                                                                   :argument-name "id"
-                                                                   :value         4
-                                                                   :v/parentk     :arguments
-                                                                   :v/path        ["Person" "id"]}]
-                                                     :selection-set
-                                                                 [{:node-type  :field
-                                                                   :field-name "id"
-                                                                   :v/parentk  :selection-set
-                                                                   :v/path     ["Person" "id"]}
-                                                                  {:node-type  :field
-                                                                   :field-name "name"
-                                                                   :v/parentk  :selection-set
-                                                                   :v/path     ["Person" "name"]}
-                                                                  {:node-type  :field
-                                                                   :field-name "profilePic"
-                                                                   :arguments
-                                                                               [{:node-type     :argument
-                                                                                 :argument-name "width"
-                                                                                 :value         100
-                                                                                 :v/parentk     :arguments
-                                                                                 :v/path        ["Person" "profilePic" "width"]}
-                                                                                {:node-type     :argument
-                                                                                 :argument-name "height"
-                                                                                 :value         50.0
-                                                                                 :v/parentk     :arguments
-                                                                                 :v/path        ["Person" "profilePic" "height"]}]
-                                                                   :v/parentk  :selection-set
-                                                                   :v/path     ["Person" "profilePic"]}]
-                                                     :v/parentk  :selection-set
-                                                     :v/path     ["Person"]}]}]
-                          :state nil}
-   :fragment-definitions {:node nil :state nil}})
+  {:document
+   {:type-system-definitions
+                          [{:node-type :schema-definition
+                            :query-type {:name "QueryRoot"}
+                            :section :type-system-definitions
+                            :kind :SCHEMA
+                            :v/parentk :children
+                            :v/path []}
+                           {:node-type :type-definition
+                            :type-name "QueryRoot"
+                            :section :type-system-definitions
+                            :fields
+                                       [{:node-type :type-field
+                                         :field-name "person"
+                                         :type-name "Person"
+                                         :arguments
+                                         [{:node-type :type-field-argument
+                                           :argument-name "id"
+                                           :type-name "Int"
+                                           :v/parentk :arguments
+                                           :v/path ["Person" "id"]}]
+                                         :v/parentk :fields
+                                         :v/path ["Person"]}]
+                            :kind :OBJECT
+                            :v/parentk :children
+                            :v/path []}
+                           {:node-type :type-definition
+                            :type-name "Person"
+                            :section :type-system-definitions
+                            :fields
+                                       [{:node-type :type-field
+                                         :field-name "name"
+                                         :type-name "String"
+                                         :v/parentk :fields
+                                         :v/path ["Person" "name"]}
+                                        {:node-type :type-field
+                                         :field-name "age"
+                                         :type-name "Int"
+                                         :v/parentk :fields
+                                         :v/path ["Person" "age"]}
+                                        {:node-type :type-field
+                                         :field-name "picture"
+                                         :type-name "Float"
+                                         :v/parentk :fields
+                                         :v/path ["Person" "picture"]}]
+                            :kind :OBJECT
+                            :v/parentk :children
+                            :v/path ["Person"]}]
+    :operation-definitions
+                          [{:section :operation-definitions
+                            :node-type :operation-definition
+                            :operation-type {:type "query" :name "NullableValues"}
+                            :selection-set
+                            [{:node-type :field
+                              :field-name "person"
+                              :arguments
+                              [{:node-type :argument
+                                :argument-name "id"
+                                :value 4
+                                :v/parentk :arguments
+                                :v/path ["Person" "id"]}]
+                              :selection-set
+                              [{:node-type :field
+                                :field-name "id"
+                                :v/parentk :selection-set
+                                :v/path ["Person" "id"]}
+                               {:node-type :field
+                                :field-name "name"
+                                :v/parentk :selection-set
+                                :v/path ["Person" "name"]}
+                               {:node-type :field
+                                :field-name "profilePic"
+                                :arguments
+                                [{:node-type :argument
+                                  :argument-name "width"
+                                  :value 100
+                                  :v/parentk :arguments
+                                  :v/path ["Person" "profilePic" "width"]}
+                                 {:node-type :argument
+                                  :argument-name "height"
+                                  :value 50.0
+                                  :v/parentk :arguments
+                                  :v/path ["Person" "profilePic" "height"]}]
+                                :v/parentk :selection-set
+                                :v/path ["Person" "profilePic"]}]
+                              :v/parentk :selection-set
+                              :v/path ["Person"]}]
+                            :v/parentk :children
+                            :v/path []}]
+    :fragment-definitions nil}
+   :state
+   {:type-system-definitions {}
+    :operation-definitions {}
+    :fragment-definitions {}}})
 
 (def visited-spec-document
-  {:type-system-definitions
-                         {:node
-                                 [{:node-type :type-definition
-                                   :type-name "Person"
-                                   :section   :type-system-definitions
-                                   :fields
-                                              [{:node-type  :type-field
-                                                :field-name "name"
-                                                :type-name  "String"
-                                                :v/parentk  :fields
-                                                :v/path     ["Person" "name"]
-                                                :spec       :graphql-clj.spec/Person-name}
-                                               {:node-type  :type-field
-                                                :field-name "age"
-                                                :type-name  "Int"
-                                                :v/parentk  :fields
-                                                :v/path     ["Person" "age"]
-                                                :spec       :graphql-clj.spec/Person-age}
-                                               {:node-type  :type-field
-                                                :field-name "picture"
-                                                :type-name  "Float"
-                                                :v/parentk  :fields
-                                                :v/path     ["Person" "picture"]
-                                                :spec       :graphql-clj.spec/Person-picture}]
-                                   :kind      :OBJECT
-                                   :spec      :graphql-clj.spec/Person}]
-                          :state nil}
-   :operation-definitions
-                         {:node
-                                 [{:section        :operation-definitions
-                                   :node-type      :operation-definition
-                                   :operation-type {:type "query" :name "NullableValues"}
-                                   :selection-set
-                                                   [{:node-type  :field
-                                                     :field-name "Person"
-                                                     :arguments
-                                                                 [{:node-type     :argument
-                                                                   :argument-name "id"
-                                                                   :value         4
-                                                                   :v/parentk     :arguments
-                                                                   :v/path        ["Person" "id"]
-                                                                   :spec          :graphql-clj.spec/arg-Person-id}]
-                                                     :selection-set
-                                                                 [{:node-type  :field
-                                                                   :field-name "id"
-                                                                   :v/parentk  :selection-set
-                                                                   :v/path     ["Person" "id"]
-                                                                   :spec       :graphql-clj.spec/Person-id}
-                                                                  {:node-type  :field
-                                                                   :field-name "name"
-                                                                   :v/parentk  :selection-set
-                                                                   :v/path     ["Person" "name"]
-                                                                   :spec       :graphql-clj.spec/Person-name}
-                                                                  {:node-type  :field
-                                                                   :field-name "profilePic"
-                                                                   :arguments
-                                                                               [{:node-type     :argument
-                                                                                 :argument-name "width"
-                                                                                 :value         100
-                                                                                 :v/parentk     :arguments
-                                                                                 :v/path        ["Person" "profilePic" "width"]
-                                                                                 :spec          :graphql-clj.spec/arg-Person-profilePic-width}
-                                                                                {:node-type     :argument
-                                                                                 :argument-name "height"
-                                                                                 :value         50.0
-                                                                                 :v/parentk     :arguments
-                                                                                 :v/path        ["Person" "profilePic" "height"]
-                                                                                 :spec          :graphql-clj.spec/arg-Person-profilePic-height}]
-                                                                   :v/parentk  :selection-set
-                                                                   :v/path     ["Person" "profilePic"]
-                                                                   :spec       :graphql-clj.spec/Person-profilePic}]
-                                                     :v/parentk  :selection-set
-                                                     :v/path     ["Person"]
-                                                     :spec       :graphql-clj.spec/Person}]}]
-                          :state nil}
-   :fragment-definitions {:node nil :state nil}})
+  {:document
+   {:type-system-definitions
+                          [{:node-type :schema-definition
+                            :query-type {:name "QueryRoot"}
+                            :section :type-system-definitions
+                            :kind :SCHEMA
+                            :v/parentk :children
+                            :v/path []}
+                           {:node-type :type-definition
+                            :type-name "QueryRoot"
+                            :section :type-system-definitions
+                            :fields
+                                       [{:node-type :type-field
+                                         :field-name "person"
+                                         :type-name "Person"
+                                         :arguments
+                                         [{:node-type :type-field-argument
+                                           :argument-name "id"
+                                           :type-name "Int"
+                                           :v/parentk :arguments
+                                           :v/path ["Person" "id"]
+                                           :spec :graphql-clj.spec/arg-Person-id}]
+                                         :v/parentk :fields
+                                         :v/path ["Person"]
+                                         :spec :graphql-clj.spec/Person}]
+                            :kind :OBJECT
+                            :v/parentk :children
+                            :v/path []}
+                           {:node-type :type-definition
+                            :type-name "Person"
+                            :section :type-system-definitions
+                            :fields
+                                       [{:node-type :type-field
+                                         :field-name "name"
+                                         :type-name "String"
+                                         :v/parentk :fields
+                                         :v/path ["Person" "name"]
+                                         :spec :graphql-clj.spec/Person-name}
+                                        {:node-type :type-field
+                                         :field-name "age"
+                                         :type-name "Int"
+                                         :v/parentk :fields
+                                         :v/path ["Person" "age"]
+                                         :spec :graphql-clj.spec/Person-age}
+                                        {:node-type :type-field
+                                         :field-name "picture"
+                                         :type-name "Float"
+                                         :v/parentk :fields
+                                         :v/path ["Person" "picture"]
+                                         :spec :graphql-clj.spec/Person-picture}]
+                            :kind :OBJECT
+                            :v/parentk :children
+                            :v/path ["Person"]
+                            :spec :graphql-clj.spec/Person}]
+    :operation-definitions
+                          [{:section :operation-definitions
+                            :node-type :operation-definition
+                            :operation-type {:type "query" :name "NullableValues"}
+                            :selection-set
+                            [{:node-type :field
+                              :field-name "person"
+                              :arguments
+                              [{:node-type :argument
+                                :argument-name "id"
+                                :value 4
+                                :v/parentk :arguments
+                                :v/path ["Person" "id"]
+                                :spec :graphql-clj.spec/arg-Person-id}]
+                              :selection-set
+                              [{:node-type :field
+                                :field-name "id"
+                                :v/parentk :selection-set
+                                :v/path ["Person" "id"]
+                                :spec :graphql-clj.spec/Person-id}
+                               {:node-type :field
+                                :field-name "name"
+                                :v/parentk :selection-set
+                                :v/path ["Person" "name"]
+                                :spec :graphql-clj.spec/Person-name}
+                               {:node-type :field
+                                :field-name "profilePic"
+                                :arguments
+                                [{:node-type :argument
+                                  :argument-name "width"
+                                  :value 100
+                                  :v/parentk :arguments
+                                  :v/path ["Person" "profilePic" "width"]
+                                  :spec :graphql-clj.spec/arg-Person-profilePic-width}
+                                 {:node-type :argument
+                                  :argument-name "height"
+                                  :value 50.0
+                                  :v/parentk :arguments
+                                  :v/path ["Person" "profilePic" "height"]
+                                  :spec :graphql-clj.spec/arg-Person-profilePic-height}]
+                                :v/parentk :selection-set
+                                :v/path ["Person" "profilePic"]
+                                :spec :graphql-clj.spec/Person-profilePic}]
+                              :v/parentk :selection-set
+                              :v/path ["Person"]
+                              :spec :graphql-clj.spec/Person}]
+                            :v/parentk :children
+                            :v/path []}]
+    :fragment-definitions nil}
+   :state
+   {:type-system-definitions {}
+    :operation-definitions {}
+    :fragment-definitions {}}} )
 
 (deftest adding-path
   (testing "DFS traversal adding the path as we go"

--- a/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
@@ -6,7 +6,7 @@ tests:
     given:
       query: |
         query BadArgumentValue {
-          Dog { name(surname: "notaboolean") }
+          dog { name(surname: "notaboolean") }
         }
     when:
       validate: [ArgumentsOfCorrectType]


### PR DESCRIPTION
- Adds a missing mapping from root query fields to their types - the test scenario was using `query { Dog` instead of `query { dog`.
- Threads root query field mapping and root query field name to zipper and via visitor state to visitor functions.  To include context from the schema here when validating statements (some validations will require the full schema).
- Eliminate possibility of creating a circular spec reference
- Switch to a post-order traversal for the spec visitor - unfortunately - for object types, their fields do not yet have specs in a pre-order traversal (and there could be other order dependencies between object types that refer to other object types).  As far as I can tell, we can't define a spec until after the referenced types are defined.  This means that any validation that depends on specs will need to use a post-order as well (different from graphql-js)
- Merge `:node` and `:state` after a validation pass
- Add helper macros to define visitors that only expect to receive map inputs to enable destructuring
