### PR TITLE
Basic schema and statement validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+- Pass existing validation CATs (including error messages, mostly, code is still overly complex), including valid and invalid examples
+- Namespace schema (and statement variable) types for global spec naming
+- Define specs at the end after walking the entire tree (rather than as we go). Support validation of recursive object types.
+- Support whitespace at the beginning / end of a schema or statement
+- Extra eval protection for defining specs only
+- Simplify approach to optional vs. required
+- Support types for nested lists, including required
+- Split schema and statement validation into 2 passes each - one for resolving specs, two for validation rules using them
+- Add a defnodevisitor macro to operate exclusively on nodes of a certain type
+- Fix some invalid schema scenarios
+- Support required for scalars (but not yet for other types)
 
 ## [0.1.15] - 2016-10-11
 - Fix aliasing. By Marcin Kulik (sickill).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ The implementation of the library follow closely to the GraphQL Draft RFC Specif
 - [ ] Comment as meta data
     * https://github.com/facebook/graphql/issues/200
     * https://github.com/graphql-java/graphql-java/issues/183
+- [ ] Relay support
+    * https://facebook.github.io/relay/docs/graphql-relay-specification.html
+    * https://facebook.github.io/relay/graphql/connections.htm
+    * https://facebook.github.io/relay/graphql/objectidentification.htm
+    * https://facebook.github.io/relay/graphql/mutations.htm
 
 ## Installation
 

--- a/src/graphql.bnf
+++ b/src/graphql.bnf
@@ -1,4 +1,4 @@
-Document ::= Definition+
+Document ::= <Ignored> Definition+ <Ignored>
 Definition ::= TypeSystemDefinition | OperationDefinition | FragmentDefinition
 OperationDefinition ::= <Ignored> OperationType? <Ignored> VariableDefinitions? <Ignored> Directives? SelectionSet
 Query ::= "query"

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -4,7 +4,9 @@
             [graphql-clj.visitor :as v]
             [clojure.walk :as walk]
             [graphql-clj.error :as ge]
-            [zip.visit :as zv]))
+            [zip.visit :as zv]
+            [clojure.spec :as s]
+            [graphql-clj.type :as type]))
 
 (def base-ns "graphql-clj")
 
@@ -30,9 +32,13 @@
 (doseq [[n pred] default-specs] ;; Register specs for global base / default / scalar types
   (eval (list 'clojure.spec/def (keyword base-ns n) pred)))
 
+(def base-type-names (set (keys type/default-types)))
 (def default-type-names (set (keys default-specs)))
 
 (defn- add-required [n] (str n "!"))
+
+(defn- to-type-name [{:keys [type-name required]}] ;; TODO required is not supported for non-scalar types
+  (if (and required (base-type-names type-name)) (add-required type-name) type-name))
 
 (defn- spec-namespace [{:keys [schema-hash statement-hash]} path]
   (->> (butlast path) (mapv name) (into [base-ns (or schema-hash statement-hash)]) (str/join ".")))
@@ -43,7 +49,7 @@
   (cond (default-type-names (first path)) (keyword base-ns (first path))
         (keyword? path)                   path
         (vector? path)                    (keyword (spec-namespace s path) (name (last path)))
-        :else (ge/throw-error "Unhandled named-spec case" {:path path})))
+        :else                             (ge/throw-error "Unhandled named-spec case" {:path path})))
 
 (defn- type-names->args [type-names]
   (mapcat #(vector % %) type-names))
@@ -58,11 +64,7 @@
   ([s path pred]
    (cond (keyword? (last path)) [(last path)]
          (recursive? path pred) [pred]
-         :else                  (register-idempotent (named-spec s path) pred)))
-  ([s path pred required]
-   (if required
-     (register-idempotent s (append-pathlast path "!") pred)
-     (register-idempotent s path #(or (nil? %) (pred %))))))
+         :else                  (register-idempotent (named-spec s path) pred))))
 
 (defn- field->spec [s {:keys [v/path]}]
   (named-spec s path))
@@ -94,8 +96,8 @@
       (extension-type s type-def)
       (base-type s type-def))))
 
-(defmethod spec-for :variable-definition [s {:keys [v/path type-name]}]
-  (register-idempotent (dissoc s :schema-hash) (into ["var"] path) (named-spec s [type-name])))
+(defmethod spec-for :variable-definition [s {:keys [v/path] :as n}]
+  (register-idempotent (dissoc s :schema-hash) (into ["var"] path) (named-spec s [(to-type-name n)])))
 
 (defmethod spec-for :input-definition [s {:keys [type-name fields]}]
   (register-idempotent s [type-name] (to-keys s fields)))
@@ -113,24 +115,25 @@
 
 (defn- coll-of
   "Recursively build up a nested collection"
-  [s inner-type]
-  (list 'clojure.spec/coll-of (if (:type-name inner-type)
-                                (named-spec s [(:type-name inner-type)])
-                                (coll-of s (:inner-type inner-type)))))
+  [s {:keys [inner-type required]}]
+  (let [coll-list (list 'clojure.spec/coll-of (if (:type-name inner-type)
+                                                (named-spec s [(to-type-name inner-type)])
+                                                (coll-of s inner-type)))]
+    (if required coll-list (list 'clojure.spec/nilable coll-list))))
 
-(defmethod spec-for :list [s {:keys [inner-type v/path]}] ;; TODO ignores required
-  (register-idempotent s path (coll-of s inner-type)))
+(defmethod spec-for :list [s {:keys [v/path] :as n}]
+  (register-idempotent s path (coll-of s n)))
 
-(defn- register-type-field [s path type-name]
-  (if (and (= (count path) 1) (= type-name (first path)))
-    [(named-spec s [type-name])]
-    (register-idempotent s path (named-spec s [type-name]))))
+(defn- register-type-field [s {:keys [v/path] :as n}]
+  (if (and (= (count path) 1) (= (:type-name n) (first path)))
+    [(named-spec s [(to-type-name n)])]
+    (register-idempotent s path (named-spec s [(to-type-name n)]))))
 
-(defmethod spec-for :type-field [s {:keys [v/path type-name]}]
-  (register-type-field s path type-name))
+(defmethod spec-for :type-field [s n]
+  (register-type-field s n))
 
-(defmethod spec-for :input-type-field [s {:keys [v/path type-name]}]
-  (register-type-field s path type-name))
+(defmethod spec-for :input-type-field [s n]
+  (register-type-field s n))
 
 (defmethod spec-for :field [s {:keys [v/path]}]
   [(named-spec s path)])
@@ -138,8 +141,8 @@
 (defmethod spec-for :argument [s {:keys [v/path]}]
   [(named-spec s (into ["arg"] path))])
 
-(defmethod spec-for :type-field-argument [s {:keys [v/path type-name]}]
-  (register-idempotent s (into ["arg"] path) (named-spec s [type-name])))
+(defmethod spec-for :type-field-argument [s {:keys [v/path] :as n}]
+  (register-idempotent s (into ["arg"] path) (named-spec s [(to-type-name n)])))
 
 (defmethod spec-for :default [_ _])
 

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -95,8 +95,7 @@
       (base-type s type-def))))
 
 (defmethod spec-for :variable-definition [s {:keys [v/path type-name]}]
-  (let [s' (dissoc s :schema-hash)]                         ;; TODO can vars refer to other vars?
-    (register-idempotent s' (into ["var"] path) (named-spec s [type-name]))))
+  (register-idempotent (dissoc s :schema-hash) (into ["var"] path) (named-spec s [type-name])))
 
 (defmethod spec-for :input-definition [s {:keys [type-name fields]}]
   (register-idempotent s [type-name] (to-keys s fields)))
@@ -149,7 +148,9 @@
 (def define-specs)
 (zv/defvisitor define-specs :post [n s]
   (when (seq? n)
-    (doseq [d (some-> s :spec-defs reverse)] (eval d))      ;; TODO is this eval a potential security concern?  Has user input been entirely sanitized?
+    (doseq [d (some-> s :spec-defs reverse)]
+      (assert (= (first d) 'clojure.spec/def)) ;; Protect against unexpected statement eval
+      (eval d))
     {:state (dissoc s :spec-defs)}))
 
 (def keywordize)

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -162,5 +162,4 @@
 (v/defmapvisitor add-spec :post [n s]
   (when-let [[spec-name spec-def] (spec-for s n)]
     (cond-> {:node (assoc n :spec spec-name)}
-            spec-def (assoc :state (-> (update s :spec-defs conj spec-def)
-                                       (assoc-in [:spec-map spec-name] spec-def))))))
+            spec-def (assoc :state (update s :spec-defs conj spec-def)))))

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -46,8 +46,9 @@
   ([n pred]
    (eval (list 'clojure.spec/def n pred)))
   ([schema-hash path pred]
-   (cond (keyword? (last path))                    (last path)
-         (or (string? path) (string? (last path))) (register-idempotent (named-spec schema-hash path) pred)))
+   (if (keyword? (last path))
+     (last path)
+     (register-idempotent (named-spec schema-hash path) pred)))
   ([schema-hash path pred required]
    (if required
      (register-idempotent schema-hash (append-pathlast path "!") pred)

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -10,8 +10,6 @@
    "Boolean" {:type-name "Boolean" :kind :SCALAR}
    "ID"      {:type-name "ID"      :kind :SCALAR}})
 
-(def default-type-names (set (keys default-types)))
-
 (defn query-root-name
   "Given a parsed schema document, return the query-root-name (default is Query)"
   [parsed-schema]                           ;; TODO deduplicate, TODO test

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -4,11 +4,11 @@
             [graphql-clj.introspection :as intro]))
 
 (def default-types
-  {"Int"     {:type-name "Int"     :kind :SCALAR :pred int?}
-   "Float"   {:type-name "Float"   :kind :SCALAR :pred double?}
-   "String"  {:type-name "String"  :kind :SCALAR :pred string?}
-   "Boolean" {:type-name "Boolean" :kind :SCALAR :pred boolean?}
-   "ID"      {:type-name "ID"      :kind :SCALAR :pred string?}})
+  {"Int"     {:type-name "Int"     :kind :SCALAR}
+   "Float"   {:type-name "Float"   :kind :SCALAR}
+   "String"  {:type-name "String"  :kind :SCALAR}
+   "Boolean" {:type-name "Boolean" :kind :SCALAR}
+   "ID"      {:type-name "ID"      :kind :SCALAR}})
 
 (def default-type-names (set (keys default-types)))
 

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -4,11 +4,13 @@
             [graphql-clj.introspection :as intro]))
 
 (def default-types
-  {"Int"     {:type-name "Int"     :kind :SCALAR}
-   "Float"   {:type-name "Float"   :kind :SCALAR}
-   "String"  {:type-name "String"  :kind :SCALAR}
-   "Boolean" {:type-name "Boolean" :kind :SCALAR}
-   "ID"      {:type-name "ID"      :kind :SCALAR}})
+  {"Int"     {:type-name "Int"     :kind :SCALAR :pred int?}
+   "Float"   {:type-name "Float"   :kind :SCALAR :pred double?}
+   "String"  {:type-name "String"  :kind :SCALAR :pred string?}
+   "Boolean" {:type-name "Boolean" :kind :SCALAR :pred boolean?}
+   "ID"      {:type-name "ID"      :kind :SCALAR :pred string?}})
+
+(def default-type-names (set (keys default-types)))
 
 (defn query-root-name
   "Given a parsed schema document, return the query-root-name (default is Query)"

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -5,7 +5,7 @@
             [graphql-clj.spec :as spec]))
 
 (def specified-rules
-  (flatten [[spec/add-spec]
+  (flatten [[spec/keywordize spec/add-spec]
             graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules]))
 

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -2,8 +2,7 @@
   (:require [graphql-clj.validator.rules.default-values-of-correct-type]
             [graphql-clj.validator.rules.arguments-of-correct-type]
             [graphql-clj.visitor :as visitor]
-            [graphql-clj.spec :as spec]
-            [clojure.spec :as s]))
+            [graphql-clj.spec :as spec]))
 
 (def first-pass-rules
   [spec/keywordize spec/add-spec spec/define-specs])
@@ -11,8 +10,6 @@
 (def second-pass-rules
   (flatten [graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules]))
-
-(def specified-rules (into first-pass-rules second-pass-rules))
 
 (defn- validate [visit-fn ]
   (try (visit-fn)

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -19,7 +19,7 @@
        (catch Exception e {:errors [(.getMessage e)]})))
 
 (defn- validate-schema*
-  "Do a 2 pass validation
+  "Do a 2 pass validation of a schema
    - First pass to add specs and validate that all types resolve.
    - Second pass to apply all the validator rules.
    There may be a clever way to avoid 2 passes...but for now it seems more interesting to be feature complete"
@@ -28,10 +28,17 @@
         {:keys [document]} (visitor/visit-document schema s first-pass-rules)]
     (assoc s :schema (:document (visitor/visit-document document s second-pass-rules)))))
 
+(defn validate-statement*
+  "Do a 2 pass validation of a statement"
+  [document' schema]
+  (let [s (assoc schema :statement-hash (hash document'))
+        {:keys [document]} (visitor/visit-document document' s first-pass-rules)]
+    (visitor/visit-document document s second-pass-rules)))
+
 ;; Public API
 
 (defn validate-schema [schema]
   (validate #(validate-schema* schema)))
 
 (defn validate-statement [document schema]
-  (validate #(visitor/visit-document document (assoc schema :statement-hash (hash document)) specified-rules)))
+  (validate #(validate-statement* document schema)))

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -2,21 +2,31 @@
   (:require [graphql-clj.validator.rules.default-values-of-correct-type]
             [graphql-clj.validator.rules.arguments-of-correct-type]
             [graphql-clj.visitor :as visitor]
-            [graphql-clj.spec :as spec]))
+            [graphql-clj.spec :as spec]
+            [clojure.spec :as s]))
 
-(def specified-rules
-  (flatten [[spec/keywordize spec/add-spec]
-            graphql-clj.validator.rules.default-values-of-correct-type/rules
+(def first-pass-rules
+  [spec/keywordize spec/add-spec spec/define-specs])
+
+(def second-pass-rules
+  (flatten [graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules]))
+
+(def specified-rules (into first-pass-rules second-pass-rules))
 
 (defn- validate [visit-fn ]
   (try (visit-fn)
-       (catch Exception e {:state {:errors [(.getMessage e)]}})))
+       (catch Exception e (do {:errors [(.getMessage e)]}))))
 
-(defn- validate-schema* [schema] ;; TODO inject introspection schema?
+(defn- validate-schema*
+  "Do a 2 pass validation
+   - First pass to add specs and validate that all types resolve.
+   - Second pass to apply all the validator rules.
+   There may be a clever way to avoid 2 passes...but for now it seems more interesting to be feature complete"
+  [schema] ;; TODO inject introspection schema?
   (let [s (visitor/initial-state schema)
-        validated-schema (visitor/visit-document schema s specified-rules)]
-    (assoc s :schema (:document validated-schema))))
+        {:keys [document]} (visitor/visit-document schema s first-pass-rules)]
+    (assoc s :schema (:document (visitor/visit-document document s second-pass-rules)))))
 
 ;; Public API
 

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -9,10 +9,19 @@
             graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules]))
 
-(defn validate-schema [schema]                              ;; TODO inject introspection schema?
+(defn- validate [visit-fn ]
+  (try (visit-fn)
+       (catch Exception e {:state {:errors [(.getMessage e)]}})))
+
+(defn- validate-schema* [schema] ;; TODO inject introspection schema?
   (let [s (visitor/initial-state schema)
         validated-schema (visitor/visit-document schema s specified-rules)]
     (assoc s :schema (:document validated-schema))))
 
+;; Public API
+
+(defn validate-schema [schema]
+  (validate #(validate-schema* schema)))
+
 (defn validate-statement [document schema]
-  (visitor/visit-document document schema specified-rules))
+  (validate #(visitor/visit-document document schema specified-rules)))

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -16,7 +16,7 @@
 
 (defn- validate [visit-fn ]
   (try (visit-fn)
-       (catch Exception e (do {:errors [(.getMessage e)]}))))
+       (catch Exception e {:errors [(.getMessage e)]})))
 
 (defn- validate-schema*
   "Do a 2 pass validation

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -34,4 +34,4 @@
   (validate #(validate-schema* schema)))
 
 (defn validate-statement [document schema]
-  (validate #(visitor/visit-document document schema specified-rules)))
+  (validate #(visitor/visit-document document (assoc schema :statement-hash (hash document)) specified-rules)))

--- a/src/graphql_clj/validator/errors.clj
+++ b/src/graphql_clj/validator/errors.clj
@@ -20,7 +20,7 @@
 
 (defn- missing-contains [spec containing-spec]              ;; TODO this is really complex
   (let [base-spec (s/get-spec (keyword (str (namespace containing-spec) "." (name containing-spec)) (name spec)))]
-    (format "The NotNull field '%s' of type '%s' is missing" (name spec) (name base-spec))))
+    (format "The NotNull field '%s' of type '%s' is missing" (name spec) (str/replace (name base-spec) #"\!" ""))))
 
 (def default-type-preds (set (vals spec/default-specs)))
 

--- a/src/graphql_clj/validator/errors.clj
+++ b/src/graphql_clj/validator/errors.clj
@@ -44,5 +44,4 @@
        (str/join ",")))
 
 (defn valid? [spec value path]
-  (spec/validate-referenced-spec path spec)
   (s/valid? spec value))

--- a/src/graphql_clj/validator/errors.clj
+++ b/src/graphql_clj/validator/errors.clj
@@ -1,5 +1,8 @@
 (ns graphql-clj.validator.errors
-  (:require [graphql-clj.type :as t]))
+  (:require [graphql-clj.type :as t]
+            [graphql-clj.spec :as spec]
+            [clojure.spec :as s]
+            [clojure.string :as str]))
 
 (defn- conj-error [error errors]
   (conj (or errors []) {:error error}))
@@ -7,9 +10,37 @@
 (defn update-errors [ast error]
   (update ast :errors (partial conj-error error))) ;; TODO add :loc once parse spans are preserved
 
-(defn render [v] (if (string? v) (str "\"" v "\"") v))
+(defn render-naked-object [v] ;; TODO render JSON and strip quotes - complex for the upside of matching CAT?
+  (str/replace (pr-str (into {} (map (fn [[k v]] [(str (name k) ":") v]) v))) #"\"" ""))
 
-(defn render-type-expectation [type-name]
-  (if (t/default-type-names type-name)
-    (str type-name " value expected")                               ;; TODO enum, etc?
-    (str (format "Expected '%s', found not an object" type-name)))) ;; TODO not an object is only one possible failure mode for object types
+(defn render [v] ;; TODO inconsistent and complex for the upside of matching CAT?
+  (cond (string? v) (str "\"" v "\"")
+        (map? v)    (render-naked-object v)
+        :else       v))
+
+(defn- missing-contains [spec containing-spec]              ;; TODO this is really complex
+  (let [base-spec (s/get-spec (keyword (str (namespace containing-spec) "." (name containing-spec)) (name spec)))]
+    (format "The NotNull field '%s' of type '%s' is missing" (name spec) (name base-spec))))
+
+(def default-type-preds (set (vals spec/default-specs)))
+
+;; TODO do we want to add a error message function alongside each spec
+(defn- explain-problem [spec {:keys [pred via] :as problem}] ;; TODO enum etc?
+  (cond
+
+    (= 'map? pred)
+    (format "Expected '%s', found not an object" (name (s/get-spec spec)))
+
+    (and (seq? pred) (= 'contains? (first pred)))
+    (missing-contains (last pred) (s/get-spec (first via)))
+
+    (default-type-preds pred)
+    (format "%s value expected" (name (s/get-spec spec)))
+
+    :else (throw (ex-info "Unhandled spec problem" {:spec spec :problem problem :base-spec (s/get-spec spec)}))))
+
+(defn explain-invalid [spec value] ;; TODO more complex than plumatic schema?
+  (->> (s/explain-data spec value)
+       :clojure.spec/problems
+       (map (partial explain-problem spec))
+       (str/join ",")))

--- a/src/graphql_clj/validator/errors.clj
+++ b/src/graphql_clj/validator/errors.clj
@@ -1,7 +1,15 @@
-(ns graphql-clj.validator.errors)
+(ns graphql-clj.validator.errors
+  (:require [graphql-clj.type :as t]))
 
 (defn- conj-error [error errors]
   (conj (or errors []) {:error error}))
 
 (defn update-errors [ast error]
   (update ast :errors (partial conj-error error))) ;; TODO add :loc once parse spans are preserved
+
+(defn render [v] (if (string? v) (str "\"" v "\"") v))
+
+(defn render-type-expectation [type-name]
+  (if (t/default-type-names type-name)
+    (str type-name " value expected")                               ;; TODO enum, etc?
+    (str (format "Expected '%s', found not an object" type-name)))) ;; TODO not an object is only one possible failure mode for object types

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -1,18 +1,18 @@
 (ns graphql-clj.validator.rules.arguments-of-correct-type
   "A GraphQL document is only valid if all field argument literal values are of the type expected by their position."
-  (:require [graphql-clj.validator.errors :as e]
-            [graphql-clj.visitor :refer [defmapvisitor]]
+  (:require [graphql-clj.visitor :refer [defnodevisitor]]
+            [graphql-clj.spec :as spec]
+            [graphql-clj.validator.errors :as ve]
             [clojure.spec :as s]))
 
-(defn- bad-value-error [arg-name type value]
-  (format "Argument '$%s' of type '%s' has invalid value: %s. Reason: %s value expected."
-          arg-name type value type))
+(defn- bad-value-error [{:keys [spec argument-name value]}]
+  (let [type-name (spec/get-spec-name spec)]
+    (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
+            argument-name type-name (ve/render value) (ve/render-type-expectation type-name))))
 
-(defmapvisitor bad-value :post [{:keys [spec variable-name value type-name node-type]} s]
-  (case node-type
-    :argument
-    (when (and spec value (not (s/valid? spec value)))
-      {:state (e/update-errors s (bad-value-error variable-name type-name value))})
-    nil))
+(defnodevisitor bad-value :post :argument
+  [{:keys [spec value] :as n} s]
+  (when (and spec value (not (s/valid? spec value)))
+    {:state (ve/update-errors s (bad-value-error n))}))
 
 (def rules [bad-value])

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -10,8 +10,8 @@
             argument-name type-name (ve/render value) (ve/explain-invalid spec value))))
 
 (defnodevisitor bad-value :post :argument
-  [{:keys [spec value] :as n} s]
-  (when (and spec value (not (s/valid? spec value)))
+  [{:keys [spec value v/path] :as n} s]
+  (when (and spec value (not (ve/valid? spec value path)))
     {:state (ve/update-errors s (bad-value-error (assoc n :value value)))}))
 
 (def rules [bad-value])

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -1,12 +1,11 @@
 (ns graphql-clj.validator.rules.arguments-of-correct-type
   "A GraphQL document is only valid if all field argument literal values are of the type expected by their position."
   (:require [graphql-clj.visitor :refer [defnodevisitor]]
-            [graphql-clj.spec :as spec]
             [graphql-clj.validator.errors :as ve]
             [clojure.spec :as s]))
 
 (defn- bad-value-error [{:keys [spec argument-name value]}]
-  (let [type-name (spec/get-spec-name (s/get-spec spec))]
+  (let [type-name (name (s/get-spec spec))]
     (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
             argument-name type-name (ve/render value) (ve/explain-invalid spec value))))
 

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -6,13 +6,13 @@
             [clojure.spec :as s]))
 
 (defn- bad-value-error [{:keys [spec argument-name value]}]
-  (let [type-name (spec/get-spec-name spec)]
+  (let [type-name (spec/get-spec-name (s/get-spec spec))]
     (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
-            argument-name type-name (ve/render value) (ve/render-type-expectation type-name))))
+            argument-name type-name (ve/render value) (ve/explain-invalid spec value))))
 
 (defnodevisitor bad-value :post :argument
   [{:keys [spec value] :as n} s]
   (when (and spec value (not (s/valid? spec value)))
-    {:state (ve/update-errors s (bad-value-error n))}))
+    {:state (ve/update-errors s (bad-value-error (assoc n :value value)))}))
 
 (def rules [bad-value])

--- a/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
@@ -1,30 +1,26 @@
 (ns graphql-clj.validator.rules.default-values-of-correct-type
   "A GraphQL document is only valid if all variable default values are of the type expected by their definition."
   (:require [clojure.spec :as s]
-            [graphql-clj.validator.errors :as e]
-            [graphql-clj.visitor :refer [defmapvisitor]]))
+            [graphql-clj.validator.errors :as ve]
+            [graphql-clj.visitor :refer [defnodevisitor]]))
 
-(defn- default-for-required-arg-error [var-name type]
+(defn- default-for-required-arg-error [{:keys [variable-name type-name]}]
   (format "Variable '$%s' of type '%s!' is required and will never use the default value. Perhaps you meant to use type '%s'."
-          var-name type type))
+          variable-name type-name type-name))
 
-(defmapvisitor default-for-required-field :post [{:keys [node-type required default-value variable-name type-name]} s]
-  (case node-type
-    :variable-definition
-    (when (and required default-value)
-      {:state (e/update-errors s (default-for-required-arg-error variable-name type-name))})
-    nil))
+(defnodevisitor default-for-required-field :post :variable-definition
+  [{:keys [required default-value] :as n} s]
+  (when (and required default-value)
+    {:state (ve/update-errors s (default-for-required-arg-error n))}))
 
-(defn- bad-value-for-default-error [var-name type default-value]
-  (format "Variable '$%s' of type '%s' has invalid default value: \"%s\". Reason: %s value expected."
-          var-name type default-value type))
+(defn- bad-value-for-default-error [{:keys [variable-name default-value type-name]}]
+  (format "Variable '$%s' of type '%s' has invalid default value: %s. Reason: %s."
+          variable-name type-name (ve/render default-value) (ve/render-type-expectation type-name)))
 
-(defmapvisitor bad-value-for-default :post [{:keys [node-type spec variable-name default-value type-name]} s]
-  (case node-type
-    :variable-definition
-    (when (and spec default-value (not (s/valid? spec default-value)))
-      {:state (e/update-errors s (bad-value-for-default-error variable-name type-name default-value))})
-    nil))
+(defnodevisitor bad-value-for-default :post :variable-definition
+  [{:keys [spec default-value] :as n} s]
+  (when (and spec default-value (not (s/valid? spec default-value)))
+    {:state (ve/update-errors s (bad-value-for-default-error n))}))
 
 (def rules
   [default-for-required-field

--- a/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
@@ -1,7 +1,6 @@
 (ns graphql-clj.validator.rules.default-values-of-correct-type
   "A GraphQL document is only valid if all variable default values are of the type expected by their definition."
-  (:require [clojure.spec :as s]
-            [graphql-clj.validator.errors :as ve]
+  (:require [graphql-clj.validator.errors :as ve]
             [graphql-clj.visitor :refer [defnodevisitor]]))
 
 (defn- default-for-required-arg-error [{:keys [variable-name type-name]}]
@@ -18,8 +17,8 @@
           variable-name type-name (ve/render default-value) (ve/explain-invalid spec default-value)))
 
 (defnodevisitor bad-value-for-default :post :variable-definition
-  [{:keys [spec default-value] :as n} s]
-  (when (and spec default-value (not (s/valid? spec default-value)))
+  [{:keys [spec default-value v/path] :as n} s]
+  (when (and spec default-value (not (ve/valid? spec default-value path)))
     {:state (ve/update-errors s (bad-value-for-default-error n))}))
 
 (def rules

--- a/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/default_values_of_correct_type.clj
@@ -13,9 +13,9 @@
   (when (and required default-value)
     {:state (ve/update-errors s (default-for-required-arg-error n))}))
 
-(defn- bad-value-for-default-error [{:keys [variable-name default-value type-name]}]
+(defn- bad-value-for-default-error [{:keys [variable-name default-value type-name spec]}]
   (format "Variable '$%s' of type '%s' has invalid default value: %s. Reason: %s."
-          variable-name type-name (ve/render default-value) (ve/render-type-expectation type-name)))
+          variable-name type-name (ve/render default-value) (ve/explain-invalid spec default-value)))
 
 (defnodevisitor bad-value-for-default :post :variable-definition
   [{:keys [spec default-value] :as n} s]

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -108,9 +108,21 @@
   [sym type bindings & body]
   `(def ~sym (mapvisitor ~type ~bindings ~@body)))
 
+(defmacro nodevisitor
+  [type node-type bindings & body]
+  `(fn [d# n# s#]
+     (when (and (= ~type d#) (map? n#) (= ~node-type (:node-type n#)))
+       (loop [n*# n# s*# s#]
+         (let [~bindings [n*# s*#]]
+           ~@body)))))
+
+(defmacro defnodevisitor
+  [sym type node-type bindings & body]
+  `(def ~sym (nodevisitor ~type ~node-type ~bindings ~@body)))
+
 (defn initial-state [schema]
   (let [query-root-name (type/query-root-name schema)]
-    {:query-root-name query-root-name
+    {:query-root-name   query-root-name
      :query-root-fields (type/query-root-fields query-root-name schema)}))
 
 (defn visit-document

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -123,7 +123,8 @@
 (defn initial-state [schema]
   (let [query-root-name (type/query-root-name schema)]
     {:query-root-name   query-root-name
-     :query-root-fields (type/query-root-fields query-root-name schema)}))
+     :query-root-fields (type/query-root-fields query-root-name schema)
+     :schema-hash       (hash schema)}))
 
 (defn visit-document
   ([document visitor-fns] (visit-document document (initial-state document) visitor-fns))

--- a/test/graphql_clj/spec_test.clj
+++ b/test/graphql_clj/spec_test.clj
@@ -14,7 +14,7 @@
   (testing "path with keywords"
     (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec 1234 [:ns1 :this/ns2 :graphql-clj/name]))))
 
-(def visited (visitor/visit-document vt/document [spec/add-spec]))
+(def visited (visitor/visit-document vt/document [spec/keywordize spec/add-spec]))
 
 (def schema-hash (-> visited :state :schema-hash))
 

--- a/test/graphql_clj/spec_test.clj
+++ b/test/graphql_clj/spec_test.clj
@@ -7,17 +7,17 @@
 
 (deftest named-spec
   (testing "base / default / scalar types"
-    (is (= :graphql-clj/String (spec/named-spec "hash" ["String"]))))
+    (is (= :graphql-clj/String (spec/named-spec {:schema-hash "hash"} ["String"]))))
   (testing "path with strings"
-    (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec "hash" ["ns1" "ns2" "name"])))
+    (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec {:schema-hash "hash"} ["ns1" "ns2" "name"])))
   (testing "path with keywords"
-    (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec 1234 [:ns1 :this/ns2 :graphql-clj/name]))))
+    (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec {:schema-hash 1234} [:ns1 :this/ns2 :graphql-clj/name]))))
 
 (def visited (visitor/visit-document vt/document [spec/keywordize spec/add-spec spec/define-specs]))
 
 (def schema-hash (-> visited :state :schema-hash))
 
-(defn named-spec [path] (spec/named-spec schema-hash path))
+(defn named-spec [path] (spec/named-spec {:schema-hash schema-hash} path))
 
 (defn validate-path [path v] (s/valid? (named-spec path) v))
 

--- a/test/graphql_clj/spec_test.clj
+++ b/test/graphql_clj/spec_test.clj
@@ -5,7 +5,6 @@
             [graphql-clj.visitor :as visitor]
             [graphql-clj.visitor-test :as vt]))
 
-
 (deftest named-spec
   (testing "base / default / scalar types"
     (is (= :graphql-clj/String (spec/named-spec "hash" ["String"]))))
@@ -14,7 +13,7 @@
   (testing "path with keywords"
     (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec 1234 [:ns1 :this/ns2 :graphql-clj/name]))))
 
-(def visited (visitor/visit-document vt/document [spec/keywordize spec/add-spec]))
+(def visited (visitor/visit-document vt/document [spec/keywordize spec/add-spec spec/define-specs]))
 
 (def schema-hash (-> visited :state :schema-hash))
 

--- a/test/graphql_clj/spec_test.clj
+++ b/test/graphql_clj/spec_test.clj
@@ -5,20 +5,30 @@
             [graphql-clj.visitor :as visitor]
             [graphql-clj.visitor-test :as vt]))
 
-(visitor/visit-document vt/document [spec/add-spec])
+
+(deftest named-spec
+  (testing "base / default / scalar types"
+    (is (= :graphql-clj/String (spec/named-spec "hash" ["String"]))))
+  (testing "path with strings"
+    (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec "hash" ["ns1" "ns2" "name"])))
+  (testing "path with keywords"
+    (is (= :graphql-clj.hash.ns1.ns2/name) (spec/named-spec 1234 [:ns1 :this/ns2 :graphql-clj/name]))))
+
+(def visited (visitor/visit-document vt/document [spec/add-spec]))
+
+(def schema-hash (-> visited :state :schema-hash))
+
+(defn named-spec [path] (spec/named-spec schema-hash path))
+
+(defn validate-path [path v] (s/valid? (named-spec path) v))
 
 (deftest spec-validation
   (testing "pre-order visit and add a spec to relevant nodes"
-    (is (s/valid? :graphql-clj.spec/Person-name "Name"))
-    (is (not (s/valid? :graphql-clj.spec/Person-name 42)))
-    (is (s/valid? :graphql-clj.spec/Person-age 42))
-    (is (not (s/valid? :graphql-clj.spec/Person-age "42")))
-    (is (s/valid? :graphql-clj.spec/Person-picture 13.37))
-    (is (not (s/valid? :graphql-clj.spec/Person-picture "13.37")))
-    (is (s/valid? :graphql-clj.spec/Person {"name" "Name" "age" 42 "picture" 13.37}))
-    (is (= (s/describe :graphql-clj.spec/Person) '(keys :opt (:graphql-clj.spec/Person-name
-                                                               :graphql-clj.spec/Person-age
-                                                               :graphql-clj.spec/Person-picture))))
-    (is (not (s/valid? :graphql-clj.spec/Person {:graphql-clj.spec/Person-name 42
-                                                 :graphql-clj.spec/Person-age  "42"
-                                                 :graphql-clj.spec/Person-picture "13.37"})))))
+    (is (validate-path ["Person" "name"] "Name"))
+    (is (not (validate-path ["Person" "name"] 42)))
+    (is (validate-path ["Person" "age"] 42))
+    (is (not (validate-path ["Person" "age"] "42")))
+    (is (validate-path ["Person" "picture"] 13.37))
+    (is (not (validate-path ["Person" "picture"] "13.37")))
+    (is (validate-path ["Person"] {:name "Name" :age 42 :picture 13.37}))
+    (is (not (validate-path ["Person"] {:name 42 :age  "42" :picture "13.37"})))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -4,8 +4,7 @@
             [yaml.core :as yaml]
             [graphql-clj.parser :as parser]
             [graphql-clj.parser-test :as pt]
-            [graphql-clj.test-helpers :as th]
-            [clojure.spec :as s]))
+            [graphql-clj.test-helpers :as th]))
 
 (deftest validate-schemas
   (doseq [schema pt/test-schemas]
@@ -47,7 +46,7 @@
   (testing "bad-value-for-default"
     (let [{:keys [validated expected]} (nth cats 4)]
       (is (match-error expected validated))))
-  (testing "complex variables missing required field"       ;; TODO variables can be the same across different queries, need to disambiguate them.  TODO why does $d not work here?
+  (testing "complex variables missing required field"
     (let [{:keys [validated expected]} (nth cats 5)]
       (is (match-error expected validated)))))
 

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -21,15 +21,19 @@
        (map th/parse-test-case)
        (map validate-test-case)))
 
+(defn- match-error [expected validated]
+  (= (map :error expected)
+     (->> validated :state :operation-definitions :errors (map :error))))
+
 (deftest default-values-of-correct-type
   (testing "default-for-required-field"
     (let [{:keys [validated expected]} (nth cats 3)]
-      (is (= (count expected) (-> validated :state :operation-definitions :errors count)))))
+      (is (match-error expected validated))))
   (testing "bad-value-for-default"
     (let [{:keys [validated expected]} (nth cats 4)]
-      (is (= (count expected) (->> validated :state :operation-definitions :errors count))))))
+      (is (match-error expected validated)))))
 
 (deftest arguments-of-correct-type
   (testing "bad-value"
     (let [{:keys [validated expected]} (nth cats 6)]
-      (is (= (count expected) (->> validated :state :operation-definitions :errors count))))))
+      (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -51,7 +51,7 @@
     (let [{:keys [validated expected]} (nth cats 5)]
       (is (match-error expected validated)))))
 
-(deftest arguments-of-correct-type                        ;; crazy not having the schema hash
+(deftest arguments-of-correct-type
   (testing "bad-value"
     (let [{:keys [validated expected]} (nth cats 6)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -6,20 +6,24 @@
             [graphql-clj.parser-test :as pt]
             [graphql-clj.test-helpers :as th]))
 
+(defn- schema-errors [validated]
+  (->> validated :state :type-system-definitions :errors))
+
+(defn- operation-errors [validated]
+  (->> validated :state :operation-definitions :errors))
+
 (deftest validate-schemas
   (doseq [schema pt/test-schemas]
     (testing (str "Test schema validation. schema: " schema)
       (let [validated (validator/validate-schema (parser/parse schema))]
-        (is validated)))))
+        (is (:schema validated))
+        (is (nil? (schema-errors validated)))))))
 
 (def schema
   (-> (parser/parse (slurp "test/scenarios/cats/validation/validation.schema.graphql"))
       validator/validate-schema))
 
 (assert (not (nil? schema)) "No schema found!")
-
-(defn- operation-errors [validated]
-  (->> validated :state :operation-definitions :errors))
 
 (defn validate-test-case [{:keys [parsed] :as test-case}]
   (let [validated (validator/validate-statement parsed schema)]

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -4,12 +4,14 @@
             [yaml.core :as yaml]
             [graphql-clj.parser :as parser]
             [graphql-clj.parser-test :as pt]
-            [graphql-clj.test-helpers :as th]))
+            [graphql-clj.test-helpers :as th]
+            [clojure.spec :as s]))
 
 (deftest validate-schemas
   (doseq [schema pt/test-schemas]
     (testing (str "Test schema validation. schema: " schema)
-      (is (validator/validate-schema (parser/parse schema))))))
+      (let [validated (validator/validate-schema (parser/parse schema))]
+        (is validated)))))
 
 (def schema
   (-> (parser/parse (slurp "test/scenarios/cats/validation/validation.schema.graphql"))
@@ -45,11 +47,11 @@
   (testing "bad-value-for-default"
     (let [{:keys [validated expected]} (nth cats 4)]
       (is (match-error expected validated))))
-  (testing "complex variables missing required field"
+  (testing "complex variables missing required field"       ;; TODO variables can be the same across different queries, need to disambiguate them.  TODO why does $d not work here?
     (let [{:keys [validated expected]} (nth cats 5)]
       (is (match-error expected validated)))))
 
-(deftest arguments-of-correct-type
+(deftest arguments-of-correct-type                        ;; crazy not having the schema hash
   (testing "bad-value"
     (let [{:keys [validated expected]} (nth cats 6)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -3,7 +3,13 @@
             [graphql-clj.validator :as validator]
             [yaml.core :as yaml]
             [graphql-clj.parser :as parser]
+            [graphql-clj.parser-test :as pt]
             [graphql-clj.test-helpers :as th]))
+
+(deftest validate-schemas
+  (doseq [schema pt/test-schemas]
+    (testing (str "Test schema validation. schema: " schema)
+      (is (validator/validate-schema (parser/parse schema))))))
 
 (def schema
   (-> (parser/parse (slurp "test/scenarios/cats/validation/validation.schema.graphql"))

--- a/test/graphql_clj/visitor_test.clj
+++ b/test/graphql_clj/visitor_test.clj
@@ -41,218 +41,202 @@
                                                       :value         50.0}]}]}]}]})
 
 (def visited-document
-  {:document
-   {:type-system-definitions
-                          [{:node-type :schema-definition
-                            :query-type {:name "QueryRoot"}
-                            :section :type-system-definitions
-                            :kind :SCHEMA
-                            :v/parentk :children
-                            :v/path []}
-                           {:node-type :type-definition
-                            :type-name "QueryRoot"
-                            :section :type-system-definitions
-                            :fields
-                                       [{:node-type :type-field
-                                         :field-name "person"
-                                         :type-name "Person"
-                                         :arguments
-                                         [{:node-type :type-field-argument
-                                           :argument-name "id"
-                                           :type-name "Int"
-                                           :v/parentk :arguments
-                                           :v/path ["Person" "id"]}]
-                                         :v/parentk :fields
-                                         :v/path ["Person"]}]
-                            :kind :OBJECT
-                            :v/parentk :children
-                            :v/path []}
-                           {:node-type :type-definition
-                            :type-name "Person"
-                            :section :type-system-definitions
-                            :fields
-                                       [{:node-type :type-field
-                                         :field-name "name"
-                                         :type-name "String"
-                                         :v/parentk :fields
-                                         :v/path ["Person" "name"]}
-                                        {:node-type :type-field
-                                         :field-name "age"
-                                         :type-name "Int"
-                                         :v/parentk :fields
-                                         :v/path ["Person" "age"]}
-                                        {:node-type :type-field
-                                         :field-name "picture"
-                                         :type-name "Float"
-                                         :v/parentk :fields
-                                         :v/path ["Person" "picture"]}]
-                            :kind :OBJECT
-                            :v/parentk :children
-                            :v/path ["Person"]}]
-    :operation-definitions
-                          [{:section :operation-definitions
-                            :node-type :operation-definition
-                            :operation-type {:type "query" :name "NullableValues"}
-                            :selection-set
-                            [{:node-type :field
-                              :field-name "person"
-                              :arguments
-                              [{:node-type :argument
-                                :argument-name "id"
-                                :value 4
-                                :v/parentk :arguments
-                                :v/path ["Person" "id"]}]
-                              :selection-set
-                              [{:node-type :field
-                                :field-name "id"
-                                :v/parentk :selection-set
-                                :v/path ["Person" "id"]}
-                               {:node-type :field
-                                :field-name "name"
-                                :v/parentk :selection-set
-                                :v/path ["Person" "name"]}
-                               {:node-type :field
-                                :field-name "profilePic"
-                                :arguments
-                                [{:node-type :argument
-                                  :argument-name "width"
-                                  :value 100
-                                  :v/parentk :arguments
-                                  :v/path ["Person" "profilePic" "width"]}
-                                 {:node-type :argument
-                                  :argument-name "height"
-                                  :value 50.0
-                                  :v/parentk :arguments
-                                  :v/path ["Person" "profilePic" "height"]}]
-                                :v/parentk :selection-set
-                                :v/path ["Person" "profilePic"]}]
-                              :v/parentk :selection-set
-                              :v/path ["Person"]}]
-                            :v/parentk :children
-                            :v/path []}]
-    :fragment-definitions nil}
-   :state
-   {:query-root-name "QueryRoot"
-    :query-root-fields {"person" "Person"}
-    :schema-hash  (hash document)
-    :type-system-definitions {}
-    :operation-definitions {}
-    :fragment-definitions {}}})
+  {:type-system-definitions
+                         [{:node-type  :schema-definition
+                           :query-type {:name "QueryRoot"}
+                           :section    :type-system-definitions
+                           :kind       :SCHEMA
+                           :v/parentk  :children
+                           :v/path     []}
+                          {:node-type :type-definition
+                           :type-name "QueryRoot"
+                           :section   :type-system-definitions
+                           :fields
+                                      [{:node-type  :type-field
+                                        :field-name "person"
+                                        :type-name  "Person"
+                                        :arguments
+                                                    [{:node-type     :type-field-argument
+                                                      :argument-name "id"
+                                                      :type-name     "Int"
+                                                      :v/parentk     :arguments
+                                                      :v/path        ["Person" "id"]}]
+                                        :v/parentk  :fields
+                                        :v/path     ["Person"]}]
+                           :kind      :OBJECT
+                           :v/parentk :children
+                           :v/path    []}
+                          {:node-type :type-definition
+                           :type-name "Person"
+                           :section   :type-system-definitions
+                           :fields
+                                      [{:node-type  :type-field
+                                        :field-name "name"
+                                        :type-name  "String"
+                                        :v/parentk  :fields
+                                        :v/path     ["Person" "name"]}
+                                       {:node-type  :type-field
+                                        :field-name "age"
+                                        :type-name  "Int"
+                                        :v/parentk  :fields
+                                        :v/path     ["Person" "age"]}
+                                       {:node-type  :type-field
+                                        :field-name "picture"
+                                        :type-name  "Float"
+                                        :v/parentk  :fields
+                                        :v/path     ["Person" "picture"]}]
+                           :kind      :OBJECT
+                           :v/parentk :children
+                           :v/path    ["Person"]}]
+   :operation-definitions
+                         [{:section        :operation-definitions
+                           :node-type      :operation-definition
+                           :operation-type {:type "query" :name "NullableValues"}
+                           :selection-set
+                                           [{:node-type  :field
+                                             :field-name "person"
+                                             :arguments
+                                                         [{:node-type     :argument
+                                                           :argument-name "id"
+                                                           :value         4
+                                                           :v/parentk     :arguments
+                                                           :v/path        ["Person" "id"]}]
+                                             :selection-set
+                                                         [{:node-type  :field
+                                                           :field-name "id"
+                                                           :v/parentk  :selection-set
+                                                           :v/path     ["Person" "id"]}
+                                                          {:node-type  :field
+                                                           :field-name "name"
+                                                           :v/parentk  :selection-set
+                                                           :v/path     ["Person" "name"]}
+                                                          {:node-type  :field
+                                                           :field-name "profilePic"
+                                                           :arguments
+                                                                       [{:node-type     :argument
+                                                                         :argument-name "width"
+                                                                         :value         100
+                                                                         :v/parentk     :arguments
+                                                                         :v/path        ["Person" "profilePic" "width"]}
+                                                                        {:node-type     :argument
+                                                                         :argument-name "height"
+                                                                         :value         50.0
+                                                                         :v/parentk     :arguments
+                                                                         :v/path        ["Person" "profilePic" "height"]}]
+                                                           :v/parentk  :selection-set
+                                                           :v/path     ["Person" "profilePic"]}]
+                                             :v/parentk  :selection-set
+                                             :v/path     ["Person"]}]
+                           :v/parentk      :children
+                           :v/path         []}]
+   :fragment-definitions nil})
 
 (def visited-spec-document
-  {:document
-   {:type-system-definitions
-                          [{:node-type :schema-definition
-                            :query-type {:name "QueryRoot"}
-                            :section :type-system-definitions
-                            :kind :SCHEMA
-                            :v/parentk :children
-                            :v/path []}
-                           {:node-type :type-definition
-                            :type-name "QueryRoot"
-                            :section :type-system-definitions
-                            :fields
-                                       [{:node-type :type-field
-                                         :field-name "person"
-                                         :type-name "Person"
-                                         :arguments
-                                         [{:node-type :type-field-argument
-                                           :argument-name "id"
-                                           :type-name "Int"
-                                           :v/parentk :arguments
-                                           :v/path ["Person" "id"]
-                                           :spec :graphql-clj.-586053264.arg.Person/id}]
-                                         :v/parentk :fields
-                                         :v/path ["Person"]
-                                         :spec :graphql-clj.-586053264/Person}]
-                            :kind :OBJECT
-                            :v/parentk :children
-                            :v/path []}
-                           {:node-type :type-definition
-                            :type-name "Person"
-                            :section :type-system-definitions
-                            :fields
-                                       [{:node-type :type-field
-                                         :field-name "name"
-                                         :type-name "String"
-                                         :v/parentk :fields
-                                         :v/path ["Person" "name"]
-                                         :spec :graphql-clj.-586053264.Person/name}
-                                        {:node-type :type-field
-                                         :field-name "age"
-                                         :type-name "Int"
-                                         :v/parentk :fields
-                                         :v/path ["Person" "age"]
-                                         :spec :graphql-clj.-586053264.Person/age}
-                                        {:node-type :type-field
-                                         :field-name "picture"
-                                         :type-name "Float"
-                                         :v/parentk :fields
-                                         :v/path ["Person" "picture"]
-                                         :spec :graphql-clj.-586053264.Person/picture}]
-                            :kind :OBJECT
-                            :v/parentk :children
-                            :v/path ["Person"]
-                            :spec :graphql-clj.-586053264/Person}]
-    :operation-definitions
-                          [{:section :operation-definitions
-                            :node-type :operation-definition
-                            :operation-type {:type "query" :name "NullableValues"}
-                            :selection-set
-                            [{:node-type :field
-                              :field-name "person"
-                              :arguments
-                              [{:node-type :argument
-                                :argument-name "id"
-                                :value 4
-                                :v/parentk :arguments
-                                :v/path ["Person" "id"]
-                                :spec :graphql-clj.-586053264.arg.Person/id}]
-                              :selection-set
-                              [{:node-type :field
-                                :field-name "id"
-                                :v/parentk :selection-set
-                                :v/path ["Person" "id"]
-                                :spec :graphql-clj.-586053264.Person/id}
-                               {:node-type :field
-                                :field-name "name"
-                                :v/parentk :selection-set
-                                :v/path ["Person" "name"]
-                                :spec :graphql-clj.-586053264.Person/name}
-                               {:node-type :field
-                                :field-name "profilePic"
-                                :arguments
-                                [{:node-type :argument
-                                  :argument-name "width"
-                                  :value 100
-                                  :v/parentk :arguments
-                                  :v/path ["Person" "profilePic" "width"]
-                                  :spec :graphql-clj.-586053264.arg.Person.profilePic/width}
-                                 {:node-type :argument
-                                  :argument-name "height"
-                                  :value 50.0
-                                  :v/parentk :arguments
-                                  :v/path ["Person" "profilePic" "height"]
-                                  :spec :graphql-clj.-586053264.arg.Person.profilePic/height}]
-                                :v/parentk :selection-set
-                                :v/path ["Person" "profilePic"]
-                                :spec :graphql-clj.-586053264.Person/profilePic}]
-                              :v/parentk :selection-set
-                              :v/path ["Person"]
-                              :spec :graphql-clj.-586053264/Person}]
-                            :v/parentk :children
-                            :v/path []}]
-    :fragment-definitions nil}
-   :state
-   {:query-root-name "QueryRoot"
-    :query-root-fields {"person" "Person"}
-    :schema-hash (hash document)
-    :type-system-definitions {}
-    :operation-definitions {}
-    :fragment-definitions {}}})
+  {:type-system-definitions
+                         [{:node-type  :schema-definition
+                           :query-type {:name "QueryRoot"}
+                           :section    :type-system-definitions
+                           :kind       :SCHEMA
+                           :v/parentk  :children
+                           :v/path     []}
+                          {:node-type :type-definition
+                           :type-name "QueryRoot"
+                           :section   :type-system-definitions
+                           :fields
+                                      [{:node-type  :type-field
+                                        :field-name "person"
+                                        :type-name  "Person"
+                                        :arguments
+                                                    [{:node-type     :type-field-argument
+                                                      :argument-name "id"
+                                                      :type-name     "Int"
+                                                      :v/parentk     :arguments
+                                                      :v/path        ["Person" "id"]
+                                                      :spec          :graphql-clj.-586053264.arg.Person/id}]
+                                        :v/parentk  :fields
+                                        :v/path     ["Person"]
+                                        :spec       :graphql-clj.-586053264/Person}]
+                           :kind      :OBJECT
+                           :v/parentk :children
+                           :v/path    []}
+                          {:node-type :type-definition
+                           :type-name "Person"
+                           :section   :type-system-definitions
+                           :fields
+                                      [{:node-type  :type-field
+                                        :field-name "name"
+                                        :type-name  "String"
+                                        :v/parentk  :fields
+                                        :v/path     ["Person" "name"]
+                                        :spec       :graphql-clj.-586053264.Person/name}
+                                       {:node-type  :type-field
+                                        :field-name "age"
+                                        :type-name  "Int"
+                                        :v/parentk  :fields
+                                        :v/path     ["Person" "age"]
+                                        :spec       :graphql-clj.-586053264.Person/age}
+                                       {:node-type  :type-field
+                                        :field-name "picture"
+                                        :type-name  "Float"
+                                        :v/parentk  :fields
+                                        :v/path     ["Person" "picture"]
+                                        :spec       :graphql-clj.-586053264.Person/picture}]
+                           :kind      :OBJECT
+                           :v/parentk :children
+                           :v/path    ["Person"]
+                           :spec      :graphql-clj.-586053264/Person}]
+   :operation-definitions
+                         [{:section        :operation-definitions
+                           :node-type      :operation-definition
+                           :operation-type {:type "query" :name "NullableValues"}
+                           :selection-set
+                                           [{:node-type  :field
+                                             :field-name "person"
+                                             :arguments
+                                                         [{:node-type     :argument
+                                                           :argument-name "id"
+                                                           :value         4
+                                                           :v/parentk     :arguments
+                                                           :v/path        ["Person" "id"]
+                                                           :spec          :graphql-clj.-586053264.arg.Person/id}]
+                                             :selection-set
+                                                         [{:node-type  :field
+                                                           :field-name "id"
+                                                           :v/parentk  :selection-set
+                                                           :v/path     ["Person" "id"]
+                                                           :spec       :graphql-clj.-586053264.Person/id}
+                                                          {:node-type  :field
+                                                           :field-name "name"
+                                                           :v/parentk  :selection-set
+                                                           :v/path     ["Person" "name"]
+                                                           :spec       :graphql-clj.-586053264.Person/name}
+                                                          {:node-type  :field
+                                                           :field-name "profilePic"
+                                                           :arguments
+                                                                       [{:node-type     :argument
+                                                                         :argument-name "width"
+                                                                         :value         100
+                                                                         :v/parentk     :arguments
+                                                                         :v/path        ["Person" "profilePic" "width"]
+                                                                         :spec          :graphql-clj.-586053264.arg.Person.profilePic/width}
+                                                                        {:node-type     :argument
+                                                                         :argument-name "height"
+                                                                         :value         50.0
+                                                                         :v/parentk     :arguments
+                                                                         :v/path        ["Person" "profilePic" "height"]
+                                                                         :spec          :graphql-clj.-586053264.arg.Person.profilePic/height}]
+                                                           :v/parentk  :selection-set
+                                                           :v/path     ["Person" "profilePic"]
+                                                           :spec       :graphql-clj.-586053264.Person/profilePic}]
+                                             :v/parentk  :selection-set
+                                             :v/path     ["Person"]
+                                             :spec       :graphql-clj.-586053264/Person}]
+                           :v/parentk      :children
+                           :v/path         []}]
+   :fragment-definitions nil})
 
 (deftest adding-path
   (testing "DFS traversal adding the path as we go"
-    (is (= visited-document (visitor/visit-document document []))))
+    (is (= visited-document (:document (visitor/visit-document document [])))))
   (testing "pre-order visit and add a spec to relevant nodes"
-    (is (= visited-spec-document (visitor/visit-document document [spec/add-spec])))))
+    (is (= visited-spec-document (:document (visitor/visit-document document [spec/add-spec]))))))

--- a/test/graphql_clj/visitor_test.clj
+++ b/test/graphql_clj/visitor_test.clj
@@ -4,6 +4,7 @@
             [graphql-clj.spec :as spec]
             [clojure.data]))
 
+
 (def document
   {:type-system-definitions
    [{:node-type :schema-definition
@@ -133,6 +134,7 @@
    :state
    {:query-root-name "QueryRoot"
     :query-root-fields {"person" "Person"}
+    :schema-hash  (hash document)
     :type-system-definitions {}
     :operation-definitions {}
     :fragment-definitions {}}})
@@ -159,10 +161,10 @@
                                            :type-name "Int"
                                            :v/parentk :arguments
                                            :v/path ["Person" "id"]
-                                           :spec :graphql-clj.spec/arg-Person-id}]
+                                           :spec :graphql-clj.-586053264.arg.Person/id}]
                                          :v/parentk :fields
                                          :v/path ["Person"]
-                                         :spec :graphql-clj.spec/Person}]
+                                         :spec :graphql-clj.-586053264/Person}]
                             :kind :OBJECT
                             :v/parentk :children
                             :v/path []}
@@ -175,23 +177,23 @@
                                          :type-name "String"
                                          :v/parentk :fields
                                          :v/path ["Person" "name"]
-                                         :spec :graphql-clj.spec/Person-name}
+                                         :spec :graphql-clj.-586053264.Person/name}
                                         {:node-type :type-field
                                          :field-name "age"
                                          :type-name "Int"
                                          :v/parentk :fields
                                          :v/path ["Person" "age"]
-                                         :spec :graphql-clj.spec/Person-age}
+                                         :spec :graphql-clj.-586053264.Person/age}
                                         {:node-type :type-field
                                          :field-name "picture"
                                          :type-name "Float"
                                          :v/parentk :fields
                                          :v/path ["Person" "picture"]
-                                         :spec :graphql-clj.spec/Person-picture}]
+                                         :spec :graphql-clj.-586053264.Person/picture}]
                             :kind :OBJECT
                             :v/parentk :children
                             :v/path ["Person"]
-                            :spec :graphql-clj.spec/Person}]
+                            :spec :graphql-clj.-586053264/Person}]
     :operation-definitions
                           [{:section :operation-definitions
                             :node-type :operation-definition
@@ -205,18 +207,18 @@
                                 :value 4
                                 :v/parentk :arguments
                                 :v/path ["Person" "id"]
-                                :spec :graphql-clj.spec/arg-Person-id}]
+                                :spec :graphql-clj.-586053264.arg.Person/id}]
                               :selection-set
                               [{:node-type :field
                                 :field-name "id"
                                 :v/parentk :selection-set
                                 :v/path ["Person" "id"]
-                                :spec :graphql-clj.spec/Person-id}
+                                :spec :graphql-clj.-586053264.Person/id}
                                {:node-type :field
                                 :field-name "name"
                                 :v/parentk :selection-set
                                 :v/path ["Person" "name"]
-                                :spec :graphql-clj.spec/Person-name}
+                                :spec :graphql-clj.-586053264.Person/name}
                                {:node-type :field
                                 :field-name "profilePic"
                                 :arguments
@@ -225,28 +227,29 @@
                                   :value 100
                                   :v/parentk :arguments
                                   :v/path ["Person" "profilePic" "width"]
-                                  :spec :graphql-clj.spec/arg-Person-profilePic-width}
+                                  :spec :graphql-clj.-586053264.arg.Person.profilePic/width}
                                  {:node-type :argument
                                   :argument-name "height"
                                   :value 50.0
                                   :v/parentk :arguments
                                   :v/path ["Person" "profilePic" "height"]
-                                  :spec :graphql-clj.spec/arg-Person-profilePic-height}]
+                                  :spec :graphql-clj.-586053264.arg.Person.profilePic/height}]
                                 :v/parentk :selection-set
                                 :v/path ["Person" "profilePic"]
-                                :spec :graphql-clj.spec/Person-profilePic}]
+                                :spec :graphql-clj.-586053264.Person/profilePic}]
                               :v/parentk :selection-set
                               :v/path ["Person"]
-                              :spec :graphql-clj.spec/Person}]
+                              :spec :graphql-clj.-586053264/Person}]
                             :v/parentk :children
                             :v/path []}]
     :fragment-definitions nil}
    :state
    {:query-root-name "QueryRoot"
     :query-root-fields {"person" "Person"}
+    :schema-hash (hash document)
     :type-system-definitions {}
     :operation-definitions {}
-    :fragment-definitions {}}} )
+    :fragment-definitions {}}})
 
 (deftest adding-path
   (testing "DFS traversal adding the path as we go"

--- a/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
@@ -12,5 +12,5 @@ tests:
       validate: [ArgumentsOfCorrectType]
     then:
       - error-count: 1
-      - error: "Argument 'surname' of type 'Boolean' has an invalid value: 'notaboolean'. Reason: Boolean value expected."
+      - error: "Argument 'surname' of type 'Boolean' has invalid value: \"notaboolean\". Reason: Boolean value expected."
         loc: {line: 1, column: 30}

--- a/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
@@ -78,12 +78,12 @@ tests:
   - name: complex variables missing required field
     given:
       query: |
-        query MissingRequiredField($a: ComplexInput = {intField: 3}) {
+        query MissingRequiredField($c: ComplexInput = {intField: 3}) {
           dog { name }
         }
     when:
       validate: [DefaultValuesOfCorrectType]
     then:
       - error-count: 1
-      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean' is missing."
+      - error: "Variable '$c' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean' is missing."
         loc: {line: 1, column: 47}

--- a/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
@@ -68,9 +68,9 @@ tests:
       validate: [DefaultValuesOfCorrectType]
     then:
       - error-count: 3
-      - error: "Variable '$a' of type 'Int' has invalid default value: \"one\". Reason: Int value expected"
+      - error: "Variable '$a' of type 'Int' has invalid default value: \"one\". Reason: Int value expected."
         loc: {line: 2, column: 13}
-      - error: "Variable '$b' of type 'String' has invalid default value: 4. Reason: String value expected"
+      - error: "Variable '$b' of type 'String' has invalid default value: 4. Reason: String value expected."
         loc: {line: 3, column: 16}
       - error: "Variable '$c' of type 'ComplexInput' has invalid default value: \"notverycomplex\". Reason: Expected 'ComplexInput', found not an object."
         loc: {line: 4, column: 22}

--- a/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
@@ -85,5 +85,5 @@ tests:
       validate: [DefaultValuesOfCorrectType]
     then:
       - error-count: 1
-      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' defined in the input type 'Boolean' is missing."
+      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean' is missing."
         loc: {line: 1, column: 47}

--- a/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml
@@ -78,12 +78,12 @@ tests:
   - name: complex variables missing required field
     given:
       query: |
-        query MissingRequiredField($c: ComplexInput = {intField: 3}) {
+        query MissingRequiredField($a: ComplexInput = {intField: 3}) {
           dog { name }
         }
     when:
       validate: [DefaultValuesOfCorrectType]
     then:
       - error-count: 1
-      - error: "Variable '$c' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean' is missing."
+      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean' is missing."
         loc: {line: 1, column: 47}

--- a/test/scenarios/schemas.edn
+++ b/test/scenarios/schemas.edn
@@ -85,13 +85,28 @@ mutation: Mutation
     JEDI
  }"
 
- "type Starship {
+ "enum LengthUnit {
+    METER
+    FOOT
+    INCH
+    CENTIMETER
+ }
+
+ type Starship {
    id: ID!
    name: String!
    length(unit: LengthUnit = METER): Float
  }"
 
- "type Human implements Character {
+ "
+ interface Character {
+   id: ID!
+   name: String!
+   friends: [Character]
+   appearsIn: [Episode]!
+ }
+
+ type Human implements Character {
    id: ID!
    name: String!
    friends: [Character]
@@ -107,36 +122,7 @@ mutation: Mutation
     appearsIn: [Episode]!
     primaryFunction: String
   }"
- "{
-    empireHero: hero(episode: EMPIRE) {
-      name
-    }
-    jediHero: hero(episode: JEDI) {
-      name
-    }
-  }"
- "{
-    leftComparison: hero(episode: EMPIRE) {
-      ...comparisonFields
-    }
-    rightComparison: hero(episode: JEDI) {
-      ...comparisonFields
-    }
-  }
 
-  fragment comparisonFields on Character {
-    name
-    appearsIn
-    friends {
-      name
-    }
-  }"
  "type TripleList {
     numbers: [[[Int!]]]!
- }"
-
- "mutation{
-createHuman (name:$testname, friends:[]) {
-  id
-}
-}"]
+ }"]

--- a/test/scenarios/schemas.edn
+++ b/test/scenarios/schemas.edn
@@ -1,18 +1,18 @@
 ["type Person {
   name: String
   age: Int
-  picture: Url
+  picture: String
 }
 "
  "type Person {
 name(id: ID): String
 age: Int
-picture: Url
+picture: String
 }"
  "type Person {
 name(id: ID id2: ID): String
 age: Int
-picture: Url
+picture: String
 }"
  "type Person {
 name: String
@@ -33,6 +33,8 @@ type Photo {
 height: Int
 width: Int
 }
+
+union SearchResult = Photo | Person
 
 type SearchQuery {
 firstSearchResult: SearchResult
@@ -40,7 +42,7 @@ firstSearchResult: SearchResult
  "type Person {
 name: String
 age: Int
-picture: Url
+picture: String
 relationship: Person
 }"
  "interface NamedEntity {

--- a/test/scenarios/statements.edn
+++ b/test/scenarios/statements.edn
@@ -283,4 +283,35 @@ fragment maybeFragment on Query @include(if: $condition) {
      world(flag: Boolean = true): String!
      this: Int
    }"
+ "{
+   empireHero: hero(episode: EMPIRE) {
+     name
+   }
+   jediHero: hero(episode: JEDI) {
+     name
+   }
+ }"
+
+ "{
+   leftComparison: hero(episode: EMPIRE) {
+     ...comparisonFields
+   }
+   rightComparison: hero(episode: JEDI) {
+     ...comparisonFields
+   }
+ }
+
+ fragment comparisonFields on Character {
+   name
+   appearsIn
+   friends {
+     name
+   }
+ }"
+
+ "mutation{
+createHuman (name:$testname, friends:[]) {
+ id
+}
+}"
  ]


### PR DESCRIPTION
- Pass existing validation CATs (including error messages, mostly, code is still overly complex), including valid and invalid examples
- Namespace schema (and statement variable) types for global spec naming
- Define specs at the end after walking the entire tree (rather than as we go). Support validation of recursive object types.
- Support whitespace at the beginning / end of a schema or statement
- Extra eval protection for defining specs only
- Simplify approach to optional vs. required
- Support types for nested lists, including required
- Split schema and statement validation into 2 passes each - one for resolving specs, two for validation rules using them
- Add a defnodevisitor macro to operate exclusively on nodes of a certain type
- Fix some invalid schema scenarios
- Support required for scalars (but not yet for other types)

The error rendering from spec errors to error output matching the CATS is a bit painful and incomplete.
