### PR TITLE
Validation: argument, type, and fragment names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This change
 - Implement preliminary version of FieldsOnCorrectType validation
 - Build a map from namespaced spec keyword to their corresponding nodes
 - Include full parent node in each child node (for getting to parent types)
+- Happy path implementation for validating argument and type names.
 
 ## [0.1.16] - 2016-10-12
 ### BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. This change
 - Implement preliminary version of FieldsOnCorrectType validation
 - Build a map from namespaced spec keyword to their corresponding nodes
 - Include full parent node in each child node (for getting to parent types)
-- Happy path implementation for validating argument and type names.
+- Validate argument, type, and fragment names
 
 ## [0.1.16] - 2016-10-12
 ### BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This change
 - Build a map from namespaced spec keyword to their corresponding nodes
 - Include full parent node in each child node (for getting to parent types)
 - Validate argument, type, and fragment names
+- Validate that variables are input types
 
 ## [0.1.16] - 2016-10-12
 ### BREAKING

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -179,7 +179,7 @@
 (def define-specs)
 (zv/defvisitor define-specs :post [n s]
   (when (seq? n)
-    (doseq [d (some-> s :spec-defs reverse)]
+    (doseq [d (some-> s :spec-defs)]
       (assert (= (first d) 'clojure.spec/def))              ;; Protect against unexpected statement eval
       (try (eval d) (catch Compiler$CompilerException _)))  ;; Squashing errors here to provide better error messages in validation
     {:state (dissoc s :spec-defs)}))
@@ -197,5 +197,5 @@
     (let [updated-n (-> n (assoc :spec spec-name))]
       (cond-> {:node (dissoc updated-n :v/parent)}
               spec-def (assoc :state (-> s
-                                         (update :spec-defs conj spec-def)
+                                         (update :spec-defs #(conj (or % []) spec-def))
                                          (assoc-in [:spec-map spec-name] updated-n)))))))

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -1,5 +1,5 @@
 (ns graphql-clj.spec
-  (:require [clojure.spec]
+  (:require [clojure.spec :as s]
             [clojure.string :as str]
             [graphql-clj.visitor :as v]
             [clojure.walk :as walk]
@@ -166,6 +166,14 @@
 
 (defmethod ^:private of-type :default [{:keys [spec]} _]
   spec)
+
+(defn get-type-node
+  "Given a spec, get the node definition for the corresponding base type"
+  [{:keys [spec]} s]
+  (let [base-spec (s/get-spec spec)]
+    (if (default-type-names (name base-spec))
+      {:node-type :scalar :type-name (name base-spec)}
+      (get-in s [:spec-map base-spec]))))
 
 (defn get-parent-type
   "Given a node and the global state, find the parent type"

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -6,7 +6,8 @@
             [graphql-clj.error :as ge]
             [zip.visit :as zv]
             [clojure.spec :as s]
-            [graphql-clj.type :as type]))
+            [graphql-clj.type :as type])
+  (:import [clojure.lang Compiler$CompilerException]))
 
 (def base-ns "graphql-clj")
 
@@ -172,8 +173,8 @@
 (zv/defvisitor define-specs :post [n s]
   (when (seq? n)
     (doseq [d (some-> s :spec-defs reverse)]
-      (assert (= (first d) 'clojure.spec/def)) ;; Protect against unexpected statement eval
-      (eval d))
+      (assert (= (first d) 'clojure.spec/def))              ;; Protect against unexpected statement eval
+      (try (eval d) (catch Compiler$CompilerException _)))  ;; Squashing errors here to provide better error messages in validation
     {:state (dissoc s :spec-defs)}))
 
 (def keywordize)

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -107,11 +107,16 @@
                                                                  (map (comp (partial named-spec s) vector))
                                                                  type-names->args))))
 
+;; TODO reverse order of s and n to be standard
 (defmethod spec-for :enum-definition [s {:keys [type-name fields]}]
   (register-idempotent s [type-name] (set (map :name fields))))
 
-(defmethod spec-for :fragment-definition [s {:keys [type-condition]}]
-  [(named-spec s [(:type-name type-condition)])])
+;; TODO what if some fields on the associated type are required?
+(defmethod spec-for :fragment-definition [s {:keys [v/path] :as n}]
+  (register-idempotent (dissoc s :schema-hash) ["frag" (:name n)] (named-spec s path))) ;; alternatively, (to-keys s selection-set)
+
+(defmethod spec-for :fragment-spread [s n]
+  [(named-spec (dissoc s :schema-hash) ["frag" (:name n)])])
 
 (defmethod spec-for :interface-definition [s {:keys [type-name fields]}]
   (register-idempotent s [type-name] (to-keys s fields)))

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -5,7 +5,6 @@
             [clojure.walk :as walk]
             [graphql-clj.error :as ge]
             [zip.visit :as zv]
-            [clojure.spec :as s]
             [graphql-clj.type :as type])
   (:import [clojure.lang Compiler$CompilerException]))
 
@@ -110,6 +109,9 @@
 
 (defmethod spec-for :enum-definition [s {:keys [type-name fields]}]
   (register-idempotent s [type-name] (set (map :name fields))))
+
+(defmethod spec-for :fragment-definition [s {:keys [type-condition]}]
+  [(named-spec s [(:type-name type-condition)])])
 
 (defmethod spec-for :interface-definition [s {:keys [type-name fields]}]
   (register-idempotent s [type-name] (to-keys s fields)))

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -2,6 +2,7 @@
   (:require [graphql-clj.validator.rules.default-values-of-correct-type]
             [graphql-clj.validator.rules.arguments-of-correct-type]
             [graphql-clj.validator.rules.fields-on-correct-type]
+            [graphql-clj.validator.rules.known-argument-names]
             [graphql-clj.visitor :as visitor]
             [graphql-clj.spec :as spec]
             [instaparse.core :as insta]
@@ -12,6 +13,7 @@
 
 (def second-pass-rules
   (flatten [graphql-clj.validator.rules.default-values-of-correct-type/rules
+            graphql-clj.validator.rules.known-argument-names/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules
             graphql-clj.validator.rules.fields-on-correct-type/rules]))
 

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -4,6 +4,7 @@
             [graphql-clj.validator.rules.fields-on-correct-type]
             [graphql-clj.validator.rules.known-argument-names]
             [graphql-clj.validator.rules.known-type-names]
+            [graphql-clj.validator.rules.known-fragment-names]
             [graphql-clj.visitor :as visitor]
             [graphql-clj.spec :as spec]
             [instaparse.core :as insta]
@@ -14,6 +15,7 @@
 (def second-pass-rules
   (flatten [graphql-clj.validator.rules.known-type-names/rules
             graphql-clj.validator.rules.known-argument-names/rules
+            graphql-clj.validator.rules.known-fragment-names/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules
             graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.fields-on-correct-type/rules]))

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -3,18 +3,19 @@
             [graphql-clj.validator.rules.arguments-of-correct-type]
             [graphql-clj.validator.rules.fields-on-correct-type]
             [graphql-clj.validator.rules.known-argument-names]
+            [graphql-clj.validator.rules.known-type-names]
             [graphql-clj.visitor :as visitor]
             [graphql-clj.spec :as spec]
             [instaparse.core :as insta]
             [graphql-clj.error :as ge]))
 
-(def first-pass-rules
-  [spec/keywordize spec/add-spec spec/define-specs])
+(def first-pass-rules [spec/keywordize spec/add-spec spec/define-specs])
 
 (def second-pass-rules
-  (flatten [graphql-clj.validator.rules.default-values-of-correct-type/rules
+  (flatten [graphql-clj.validator.rules.known-type-names/rules
             graphql-clj.validator.rules.known-argument-names/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules
+            graphql-clj.validator.rules.default-values-of-correct-type/rules
             graphql-clj.validator.rules.fields-on-correct-type/rules]))
 
 (defn- validate [visit-fn]

--- a/src/graphql_clj/validator.clj
+++ b/src/graphql_clj/validator.clj
@@ -5,6 +5,7 @@
             [graphql-clj.validator.rules.known-argument-names]
             [graphql-clj.validator.rules.known-type-names]
             [graphql-clj.validator.rules.known-fragment-names]
+            [graphql-clj.validator.rules.variables-are-input-types]
             [graphql-clj.visitor :as visitor]
             [graphql-clj.spec :as spec]
             [instaparse.core :as insta]
@@ -18,7 +19,8 @@
             graphql-clj.validator.rules.known-fragment-names/rules
             graphql-clj.validator.rules.arguments-of-correct-type/rules
             graphql-clj.validator.rules.default-values-of-correct-type/rules
-            graphql-clj.validator.rules.fields-on-correct-type/rules]))
+            graphql-clj.validator.rules.fields-on-correct-type/rules
+            graphql-clj.validator.rules.variables-are-input-types/rules]))
 
 (defn- validate [visit-fn]
   (try (visit-fn)

--- a/src/graphql_clj/validator/rules/known_argument_names.clj
+++ b/src/graphql_clj/validator/rules/known_argument_names.clj
@@ -1,0 +1,19 @@
+(ns graphql-clj.validator.rules.known-argument-names
+  "A GraphQL field is only valid if all supplied arguments are defined by that field."
+  (:require [graphql-clj.visitor :refer [defnodevisitor]]
+            [graphql-clj.validator.errors :as ve]
+            [clojure.spec :as s]
+            [graphql-clj.spec :as spec]))
+
+(defn- undefined-argument-error [{:keys [argument-name v/parent] :as n} s]
+  (format "Unknown argument '%s' on field '%s' of type '%s'."
+          argument-name (name (:spec parent)) (:type-name (get-in s [:spec-map (spec/get-parent-type n s)]))))
+
+(defnodevisitor undefined-argument :pre :argument
+  [{:keys [spec value v/path v/parent] :as n} s]
+  (when-not (s/get-spec spec)
+    (when (= (:node-type parent) :field) ;; TODO directives can have arguments too
+      {:state (ve/update-errors s (undefined-argument-error n s))
+       :break true})))
+
+(def rules [undefined-argument])

--- a/src/graphql_clj/validator/rules/known_fragment_names.clj
+++ b/src/graphql_clj/validator/rules/known_fragment_names.clj
@@ -8,7 +8,7 @@
   (format "Unknown fragment '%s'." name))
 
 (defnodevisitor unknown-fragment-name :pre :fragment-spread
-  [{:keys [spec value v/path v/parent] :as n} s]
+  [{:keys [spec] :as n} s]
   (when-not (s/get-spec spec)
     {:state (ve/update-errors s (unknown-fragment-error n))
      :break true}))

--- a/src/graphql_clj/validator/rules/known_fragment_names.clj
+++ b/src/graphql_clj/validator/rules/known_fragment_names.clj
@@ -1,0 +1,16 @@
+(ns graphql-clj.validator.rules.known-fragment-names
+  "A GraphQL document is only valid if all `...Fragment` fragment spreads refer to fragments defined in the same document."
+  (:require [graphql-clj.visitor :refer [defnodevisitor]]
+            [graphql-clj.validator.errors :as ve]
+            [clojure.spec :as s]))
+
+(defn- unknown-fragment-error [{:keys [name]}]
+  (format "Unknown fragment '%s'." name))
+
+(defnodevisitor unknown-fragment-name :pre :fragment-spread
+  [{:keys [spec value v/path v/parent] :as n} s]
+  (when-not (s/get-spec spec)
+    {:state (ve/update-errors s (unknown-fragment-error n))
+     :break true}))
+
+(def rules [unknown-fragment-name])

--- a/src/graphql_clj/validator/rules/known_type_names.clj
+++ b/src/graphql_clj/validator/rules/known_type_names.clj
@@ -7,18 +7,17 @@
 (defn- unknown-type-error [{:keys [type-name type-condition]}]
   (format "Unknown type '%s'." (or type-name (:type-name type-condition))))
 
-(defn- unknown-type-name* [{:keys [spec] :as n} s]
+;; TODO for schemas?
+
+(defnodevisitor unknown-type-name-variable :pre :variable-definition [{:keys [spec] :as n} s]
   (when-not (s/get-spec spec)
     {:state (ve/update-errors s (unknown-type-error n))
      :break true}))
 
-;; TODO for schemas?
-
-(defnodevisitor unknown-type-name-variable :pre :variable-definition [n s]
-  (unknown-type-name* n s))
-
-(defnodevisitor unknown-type-name-fragment :pre :fragment-definition [n s]
-  (unknown-type-name* n s))
+(defnodevisitor unknown-type-name-fragment :pre :fragment-definition [{:keys [spec] :as n} s]
+  (when-not (s/get-spec spec)
+    {:state (ve/update-errors s (unknown-type-error n))
+     :break true}))
 
 (def rules [unknown-type-name-variable
             unknown-type-name-fragment])

--- a/src/graphql_clj/validator/rules/known_type_names.clj
+++ b/src/graphql_clj/validator/rules/known_type_names.clj
@@ -4,18 +4,21 @@
             [graphql-clj.validator.errors :as ve]
             [clojure.spec :as s]))
 
-(defn- unknown-type-error [{:keys [type-name]} s]
-  (format "Unknown type '%s'." type-name))
+(defn- unknown-type-error [{:keys [type-name type-condition]}]
+  (format "Unknown type '%s'." (or type-name (:type-name type-condition))))
 
 (defn- unknown-type-name* [{:keys [spec] :as n} s]
   (when-not (s/get-spec spec)
-    {:state (ve/update-errors s (unknown-type-error n s))
+    {:state (ve/update-errors s (unknown-type-error n))
      :break true}))
 
-;; TODO for statements, fragment conditions also need to use known type names
 ;; TODO for schemas?
 
-(defnodevisitor unknown-type-name :pre :variable-definition [n s]
+(defnodevisitor unknown-type-name-variable :pre :variable-definition [n s]
   (unknown-type-name* n s))
 
-(def rules [unknown-type-name])
+(defnodevisitor unknown-type-name-fragment :pre :fragment-definition [n s]
+  (unknown-type-name* n s))
+
+(def rules [unknown-type-name-variable
+            unknown-type-name-fragment])

--- a/src/graphql_clj/validator/rules/known_type_names.clj
+++ b/src/graphql_clj/validator/rules/known_type_names.clj
@@ -12,6 +12,9 @@
     {:state (ve/update-errors s (unknown-type-error n s))
      :break true}))
 
+;; TODO for statements, fragment conditions also need to use known type names
+;; TODO for schemas?
+
 (defnodevisitor unknown-type-name :pre :variable-definition [n s]
   (unknown-type-name* n s))
 

--- a/src/graphql_clj/validator/rules/known_type_names.clj
+++ b/src/graphql_clj/validator/rules/known_type_names.clj
@@ -7,10 +7,12 @@
 (defn- unknown-type-error [{:keys [type-name]} s]
   (format "Unknown type '%s'." type-name))
 
-(defnodevisitor unknown-type-name :pre :variable-definition
-  [{:keys [spec] :as n} s]
+(defn- unknown-type-name* [{:keys [spec] :as n} s]
   (when-not (s/get-spec spec)
     {:state (ve/update-errors s (unknown-type-error n s))
      :break true}))
+
+(defnodevisitor unknown-type-name :pre :variable-definition [n s]
+  (unknown-type-name* n s))
 
 (def rules [unknown-type-name])

--- a/src/graphql_clj/validator/rules/known_type_names.clj
+++ b/src/graphql_clj/validator/rules/known_type_names.clj
@@ -1,0 +1,16 @@
+(ns graphql-clj.validator.rules.known-type-names
+  "A GraphQL document is only valid if referenced types are defined by the type schema."
+  (:require [graphql-clj.visitor :refer [defnodevisitor]]
+            [graphql-clj.validator.errors :as ve]
+            [clojure.spec :as s]))
+
+(defn- unknown-type-error [{:keys [type-name]} s]
+  (format "Unknown type '%s'." type-name))
+
+(defnodevisitor unknown-type-name :pre :variable-definition
+  [{:keys [spec] :as n} s]
+  (when-not (s/get-spec spec)
+    {:state (ve/update-errors s (unknown-type-error n s))
+     :break true}))
+
+(def rules [unknown-type-name])

--- a/src/graphql_clj/validator/rules/variables_are_input_types.clj
+++ b/src/graphql_clj/validator/rules/variables_are_input_types.clj
@@ -1,0 +1,17 @@
+(ns graphql-clj.validator.rules.variables-are-input-types
+  "A GraphQL operation is only valid if all the variables it defines are of input types (scalar, enum, or input object)."
+  (:require [graphql-clj.visitor :refer [defnodevisitor]]
+            [graphql-clj.validator.errors :as ve]
+            [clojure.spec :as s]))
+
+(defn- bad-variable-type-error [{:keys [spec argument-name value]}]
+  (let [type-name (name (s/get-spec spec))]
+    (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
+            argument-name type-name (ve/render value) (ve/explain-invalid spec value))))
+
+(defnodevisitor bad-variable-type :pre :variable-definition
+  [{:keys [spec value v/path] :as n} s]
+  (when (and spec value (not (ve/valid? spec value path)))
+    {:state (ve/update-errors s (bad-variable-type-error (assoc n :value value)))}))
+
+(def rules [bad-variable-type])

--- a/src/graphql_clj/validator/rules/variables_are_input_types.clj
+++ b/src/graphql_clj/validator/rules/variables_are_input_types.clj
@@ -2,16 +2,16 @@
   "A GraphQL operation is only valid if all the variables it defines are of input types (scalar, enum, or input object)."
   (:require [graphql-clj.visitor :refer [defnodevisitor]]
             [graphql-clj.validator.errors :as ve]
-            [clojure.spec :as s]))
+            [graphql-clj.spec :as spec]))
 
-(defn- bad-variable-type-error [{:keys [spec argument-name value]}]
-  (let [type-name (name (s/get-spec spec))]
-    (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
-            argument-name type-name (ve/render value) (ve/explain-invalid spec value))))
+(defn- bad-variable-type-error [{:keys [variable-name]} {:keys [spec]}]
+  (format "Variable '$%s' cannot be non-input type '%s'." variable-name (name spec)))
 
-(defnodevisitor bad-variable-type :pre :variable-definition
-  [{:keys [spec value v/path] :as n} s]
-  (when (and spec value (not (ve/valid? spec value path)))
-    {:state (ve/update-errors s (bad-variable-type-error (assoc n :value value)))}))
+(def acceptable-types #{:scalar :enum-definition :input-definition})
+
+(defnodevisitor bad-variable-type :pre :variable-definition [n s]
+  (let [{:keys [node-type] :as type-node} (spec/get-type-node n s)]
+    (when-not (acceptable-types node-type)
+      {:state (ve/update-errors s (bad-variable-type-error n type-node))})))
 
 (def rules [bad-variable-type])

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -14,7 +14,8 @@
    :operations-definitions #{:operation-definition}
    :interface-definition   #{:fields}
    :input-definition       #{:fields}
-   :query-root             #{:children}})
+   :query-root             #{:children}
+   :fragment-definition    #{:selection-set}})
 
 (def ^:private node-type->label-key
   {:type-definition      [:type-name]
@@ -27,7 +28,8 @@
    :type-field-argument  [:argument-name]
    :list                 [:field-name :argument-name]
    :input-type-field     [:field-name]
-   :input-definition     [:type-name]})
+   :input-definition     [:type-name]
+   :fragment-definition  [(comp :type-name :type-condition)]})
 
 ;; Zipper
 

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -60,8 +60,10 @@
       (conj parent-path child-label)
       parent-path)))
 
+(def relevant-parent-keys #{:node-type :inner-type :type-name :spec :v/parent :v/path})
+
 (defn- add-path [initial-state parentk parent child]
-  (assoc child :v/parent parent ;; TODO is this slow?
+  (assoc child :v/parent (select-keys parent relevant-parent-keys) ;; TODO is this slow?
                :v/parentk parentk
                :v/path (->> (parent-path initial-state parent)
                             (conj-child-path initial-state child))))
@@ -100,7 +102,7 @@
                     (into {}))
      :state    (->> document
                     (map (fn [[_ v]] (-> v :state (dissoc-keys initial-keys))))
-                    (merge-with merge)
+                    (apply merge-with into)
                     (into initial-state))}))
 
 ;; Public API

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -87,11 +87,13 @@
       (is (match-error expected validated)))))
 
 (deftest known-type-names
-  (testing "valid"
+  (testing "valid variable definition"
     (is (expect-valid (nth cats 14))))
   (testing "unknown type name on variable definition"
     (let [{:keys [validated expected]} (nth cats 15)]
       (is (match-error expected validated))))
+  (testing "valid fragment condition"
+    (is (expect-valid (nth cats 16))))
   (testing "unknown type name on fragment condition"
-    (let [{:keys [validated expected]} (nth cats 16)]
+    (let [{:keys [validated expected]} (nth cats 17)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -89,6 +89,9 @@
 (deftest known-type-names
   (testing "valid"
     (is (expect-valid (nth cats 14))))
-  (testing "unknown type name"
+  (testing "unknown type name on variable definition"
     (let [{:keys [validated expected]} (nth cats 15)]
+      (is (match-error expected validated))))
+  (testing "unknown type name on fragment condition"
+    (let [{:keys [validated expected]} (nth cats 16)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -36,7 +36,7 @@
        (map validate-test-case)))
 
 (defn- match-error [expected validated]
-  (= (map :error expected) (->> validated :state :errors (map :error))))
+  (= (first (map :error expected)) (->> validated :state :errors first :error)))
 
 (defn- expect-valid [{:keys [result expected]}]
   (= expected result))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -37,7 +37,7 @@
        (map validate-test-case)))
 
 (defn- match-error [expected validated]
-  (= (first (map :error expected)) (->> validated :state :errors first :error)))
+  (= (map :error expected) (->> validated :state :errors (map :error))))
 
 (defn- expect-valid [{:keys [result expected]}]
   (= expected result))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -29,7 +29,8 @@
         (get (yaml/from-file "test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/FieldsOnCorrectType.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/KnownArgumentNames.yaml") "tests")
-        (get (yaml/from-file "test/scenarios/cats/validation/KnownTypeNames.yaml") "tests")]
+        (get (yaml/from-file "test/scenarios/cats/validation/KnownTypeNames.yaml") "tests")
+        (get (yaml/from-file "test/scenarios/cats/validation/KnownFragmentNames.yaml") "tests")]
        flatten
        (map th/parse-test-case)
        (map validate-test-case)))
@@ -96,4 +97,11 @@
     (is (expect-valid (nth cats 16))))
   (testing "unknown type name on fragment condition"
     (let [{:keys [validated expected]} (nth cats 17)]
+      (is (match-error expected validated)))))
+
+(deftest known-fragment-names
+  (testing "known fragment name"
+      (is (expect-valid (nth cats 18))))
+  (testing "unknown fragment name"
+    (let [{:keys [validated expected]} (nth cats 19)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -28,7 +28,8 @@
   (->> [(get (yaml/from-file "test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/FieldsOnCorrectType.yaml") "tests")
-        (get (yaml/from-file "test/scenarios/cats/validation/KnownArgumentNames.yaml") "tests")]
+        (get (yaml/from-file "test/scenarios/cats/validation/KnownArgumentNames.yaml") "tests")
+        (get (yaml/from-file "test/scenarios/cats/validation/KnownTypeNames.yaml") "tests")]
        flatten
        (map th/parse-test-case)
        (map validate-test-case)))
@@ -81,6 +82,13 @@
 (deftest known-argument-names
   (testing "valid"
     (is (expect-valid (nth cats 12))))
-  (testing "unknown name"
+  (testing "unknown argument name"
     (let [{:keys [validated expected]} (nth cats 13)]
+      (is (match-error expected validated)))))
+
+(deftest known-type-names
+  (testing "valid"
+    (is (expect-valid (nth cats 14))))
+  (testing "unknown type name"
+    (let [{:keys [validated expected]} (nth cats 15)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -27,7 +27,8 @@
 (def cats
   (->> [(get (yaml/from-file "test/scenarios/cats/validation/DefaultValuesOfCorrectType.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml") "tests")
-        (get (yaml/from-file "test/scenarios/cats/validation/FieldsOnCorrectType.yaml") "tests")]
+        (get (yaml/from-file "test/scenarios/cats/validation/FieldsOnCorrectType.yaml") "tests")
+        (get (yaml/from-file "test/scenarios/cats/validation/KnownArgumentNames.yaml") "tests")]
        flatten
        (map th/parse-test-case)
        (map validate-test-case)))
@@ -75,4 +76,11 @@
       (is (match-error expected validated))))
   (testing "missing-type-double-nested"
     (let [{:keys [validated expected]} (nth cats 11)]
+      (is (match-error expected validated)))))
+
+(deftest known-argument-names
+  (testing "valid"
+    (is (expect-valid (nth cats 12))))
+  (testing "unknown name"
+    (let [{:keys [validated expected]} (nth cats 13)]
       (is (match-error expected validated)))))

--- a/test/graphql_clj/validator_test.clj
+++ b/test/graphql_clj/validator_test.clj
@@ -30,7 +30,8 @@
         (get (yaml/from-file "test/scenarios/cats/validation/FieldsOnCorrectType.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/KnownArgumentNames.yaml") "tests")
         (get (yaml/from-file "test/scenarios/cats/validation/KnownTypeNames.yaml") "tests")
-        (get (yaml/from-file "test/scenarios/cats/validation/KnownFragmentNames.yaml") "tests")]
+        (get (yaml/from-file "test/scenarios/cats/validation/KnownFragmentNames.yaml") "tests")
+        (get (yaml/from-file "test/scenarios/cats/validation/VariablesAreInputTypes.yaml") "tests")]
        flatten
        (map th/parse-test-case)
        (map validate-test-case)))
@@ -104,4 +105,11 @@
       (is (expect-valid (nth cats 18))))
   (testing "unknown fragment name"
     (let [{:keys [validated expected]} (nth cats 19)]
+      (is (match-error expected validated)))))
+
+(deftest variables-are-input-types
+  (testing "input type variable"
+    (is (expect-valid (nth cats 20))))
+  (testing "interface type variable"
+    (let [{:keys [validated expected]} (nth cats 21)]
       (is (match-error expected validated)))))

--- a/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
+++ b/test/scenarios/cats/validation/ArgumentsOfCorrectType.yaml
@@ -23,4 +23,4 @@ tests:
     then:
       - error-count: 1
       - error: "Argument 'surname' of type 'Boolean' has invalid value: \"notaboolean\". Reason: Boolean value expected."
-        loc: {line: 1, column: 30}
+        loc: {line: 2, column: 23}

--- a/test/scenarios/cats/validation/KnownArgumentNames.yaml
+++ b/test/scenarios/cats/validation/KnownArgumentNames.yaml
@@ -1,0 +1,26 @@
+scenario:  "Validate: Known argument names"
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: known argument
+    given:
+      query: |
+        query KnownArgument {
+          dog { name(surname: true) }
+        }
+    when:
+      validate: [KnownArgumentNames]
+    then:
+      passes:
+  - name: unknown argument
+    given:
+      query: |
+        query UnknownArgument {
+          dog { name(sur: true) }
+        }
+    when:
+      validate: [KnownArgumentNames]
+    then:
+      - error-count: 1
+      - error: "Unknown argument 'sur' on field 'name' of type 'String'."
+        loc: {line: 1, column: 13}

--- a/test/scenarios/cats/validation/KnownArgumentNames.yaml
+++ b/test/scenarios/cats/validation/KnownArgumentNames.yaml
@@ -23,4 +23,3 @@ tests:
     then:
       - error-count: 1
       - error: "Unknown argument 'sur' on field 'name' of type 'String'."
-        loc: {line: 1, column: 13}

--- a/test/scenarios/cats/validation/KnownFragmentNames.yaml
+++ b/test/scenarios/cats/validation/KnownFragmentNames.yaml
@@ -1,0 +1,27 @@
+scenario:  "Validate: Known fragment names"
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: known fragment name
+    given:
+      query: |
+        { dog { ...fragFields }}
+        fragment fragFields on Pet {
+          name
+        }
+    when:
+      validate: [KnownTypeNames]
+    then:
+      passes:
+  - name: unknown fragment name
+    given:
+      query: |
+        { dog { ...ragFields }}
+        fragment fragFields on Pet {
+          name
+        }
+    when:
+      validate: [KnownTypeNames]
+    then:
+      - error-count: 1
+      - error: "Unknown fragment 'ragFields'."

--- a/test/scenarios/cats/validation/KnownTypeNames.yaml
+++ b/test/scenarios/cats/validation/KnownTypeNames.yaml
@@ -37,10 +37,10 @@ tests:
   - name: unknown type in fragment condition
     given:
       query: |
-        { dog { ...fragFields }}
         fragment fragFields on Ret {
           name
         }
+        { dog { ...fragFields }}
     when:
       validate: [KnownTypeNames]
     then:

--- a/test/scenarios/cats/validation/KnownTypeNames.yaml
+++ b/test/scenarios/cats/validation/KnownTypeNames.yaml
@@ -12,7 +12,7 @@ tests:
       validate: [KnownTypeNames]
     then:
       passes:
-  - name: unknown type
+  - name: unknown type in variable definition
     given:
       query: |
         query UnknownType($command: RogCommand) {
@@ -23,4 +23,15 @@ tests:
     then:
       - error-count: 1
       - error: "Unknown type 'RogCommand'."
-        loc: {line: 1, column: 28}
+  - name: unknown type in fragment condition
+    given:
+      query: |
+        { dog { ...fragFields }}
+        fragment fragFields on Ret {
+          name
+        }
+    when:
+      validate: [KnownTypeNames]
+    then:
+      - error-count: 1
+      - error: "Unknown type 'Ret'."

--- a/test/scenarios/cats/validation/KnownTypeNames.yaml
+++ b/test/scenarios/cats/validation/KnownTypeNames.yaml
@@ -46,3 +46,4 @@ tests:
     then:
       - error-count: 1
       - error: "Unknown type 'Ret'."
+      - error: "Unknown fragment 'fragFields'."

--- a/test/scenarios/cats/validation/KnownTypeNames.yaml
+++ b/test/scenarios/cats/validation/KnownTypeNames.yaml
@@ -1,0 +1,26 @@
+scenario:  "Validate: Known type names"
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: known type
+    given:
+      query: |
+        query KnownType($command: DogCommand) {
+          dog { doesKnowCommand(dogCommand: $command) }
+        }
+    when:
+      validate: [KnownTypeNames]
+    then:
+      passes:
+  - name: unknown type
+    given:
+      query: |
+        query UnknownType($command: RogCommand) {
+          dog { doesKnowCommand(dogCommand: $command)}
+        }
+    when:
+      validate: [KnownTypeNames]
+    then:
+      - error-count: 1
+      - error: "Unknown type 'RogCommand'."
+        loc: {line: 1, column: 28}

--- a/test/scenarios/cats/validation/KnownTypeNames.yaml
+++ b/test/scenarios/cats/validation/KnownTypeNames.yaml
@@ -23,6 +23,17 @@ tests:
     then:
       - error-count: 1
       - error: "Unknown type 'RogCommand'."
+  - name: known type in fragment condition
+    given:
+      query: |
+        { dog { ...fragFields }}
+        fragment fragFields on Pet {
+          name
+        }
+    when:
+      validate: [KnownTypeNames]
+    then:
+      passes:
   - name: unknown type in fragment condition
     given:
       query: |

--- a/test/scenarios/cats/validation/VariablesAreInputTypes.yaml
+++ b/test/scenarios/cats/validation/VariablesAreInputTypes.yaml
@@ -1,0 +1,26 @@
+scenario: "Validate: Variables are input types"
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: valid input type variables
+    given:
+      query: |
+        query NullableValues($a: Boolean!) {
+          dog { name(surname: $a) }
+        }
+    when:
+      validate: [VariablesAreInputTypes]
+    then:
+      passes:
+
+  - name: non input type variables
+    given:
+      query: |
+        query RequiredValues($a: Intelligent!) {
+          dog { name(surname: $a) }
+        }
+    when:
+      validate: [VariablesAreInputTypes]
+    then:
+      - error-count: 1
+      - error: "Variable '$a' cannot be non-input type 'Intelligent'."


### PR DESCRIPTION
Happy path implementation for validating argument, type, and fragment names.  Also, validate that variables are input types.
