### PR TITLE
Enable the use of spec backport for Clojure < 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. This change
 - Dynamically process validation CATs.  Extend validate function to take explicit visitor functions for testing.
 - Fix bug in list type specs
 - Validate scalar leafs
+- Use spec backport for Clojure < 1.9.0
 
 ## [0.1.17] - 2016-10-14
 - Implement preliminary version of FieldsOnCorrectType validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file. This change
 - Dynamically process validation CATs.  Extend validate function to take explicit visitor functions for testing.
 - Fix bug in list type specs
 - Validate scalar leafs
-- Use spec backport for Clojure < 1.9.0
+- Make compatible with spec backport for users of Clojure < 1.9.0
 
 ## [0.1.17] - 2016-10-14
 - Implement preliminary version of FieldsOnCorrectType validation

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Add the following dependency to your project.clj file:
 
     [graphql-clj "0.1.17"]
 
+This library uses clojure.spec for validation.  If you are not yet using clojure 1.9:
+
+```
+:dependencies [[org.clojure/clojure "1.8.0"]
+               [graphql-clj "0.1.17" :exclusions [org.clojure/clojure]]
+               [clojure-spec-backport "1.9.0-alpha13"]]
+```
+
 ## Usage
 
 ### Define schema

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   :url "https://github.com/tendant/graphql-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha12"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clojure-future-spec "1.9.0-alpha13"]
                  [instaparse "1.4.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [camel-snake-kebab "0.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
   :url "https://github.com/tendant/graphql-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clojure-future-spec "1.9.0-alpha13"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha13"]
                  [instaparse "1.4.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [camel-snake-kebab "0.4.0"]

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -94,97 +94,95 @@
 ;; Spec for multimethod to add specs to relevant nodes
 
 (defmulti spec-for
-  (fn [_ {:keys [node-type type-name]}]
+  (fn [{:keys [node-type type-name]} _]
     (or node-type type-name)))
 
-(defn- extension-type [s {:keys [v/path fields type-implements]}]
+(defn- extension-type [{:keys [v/path fields type-implements]} s]
   (let [ext-spec (register-idempotent s (append-pathlast path (str delimiter "EXT")) (to-keys s fields))
         implements-specs (map (partial named-spec s) (or (:type-names type-implements) []))
         type-names (conj implements-specs ext-spec)]
     (register-idempotent s path (cons 'clojure.spec/or (type-names->args type-names)))))
 
 
-(defn- base-type [s {:keys [v/path fields]}]
+(defn- base-type [{:keys [v/path fields]} s]
   (register-idempotent s path (to-keys s fields)))
 
-(defmethod spec-for :type-definition [s {:keys [type-implements v/path] :as type-def}]
+(defmethod spec-for :type-definition [{:keys [type-implements v/path] :as type-def} s]
   (when (> (count path) 0)
     (if-not (empty? (:type-names type-implements))
-      (extension-type s type-def)
-      (base-type s type-def))))
+      (extension-type type-def s)
+      (base-type type-def s))))
 
 (defn- coll-of
   "Recursively build up a nested collection"
-  [s {:keys [inner-type required]}]
+  [{:keys [inner-type required]} s]
   (let [coll-list (list 'clojure.spec/coll-of (if (:type-name inner-type)
                                                 (named-spec s [(to-type-name inner-type)])
-                                                (coll-of s inner-type)))]
+                                                (coll-of inner-type s)))]
     (if required coll-list (list 'clojure.spec/nilable coll-list))))
 
-(defmethod spec-for :variable-definition [s {:keys [variable-name kind] :as n}]
+(defmethod spec-for :variable-definition [{:keys [variable-name kind] :as n} s]
   (if (= :LIST kind)
-    (register-idempotent (dissoc s :schema-hash) ["var" variable-name] (coll-of s n))
+    (register-idempotent (dissoc s :schema-hash) ["var" variable-name] (coll-of n s))
     (register-idempotent (dissoc s :schema-hash) ["var" variable-name] (named-spec s [(to-type-name n)]))))
 
-(defmethod spec-for :variable-usage [s {:keys [variable-name]}]
+(defmethod spec-for :variable-usage [{:keys [variable-name]} s]
   (named-spec (dissoc s :schema-hash) ["var" variable-name]))
 
-(defmethod spec-for :input-definition [s {:keys [type-name fields]}]
+(defmethod spec-for :input-definition [{:keys [type-name fields]} s]
   (register-idempotent s [type-name] (to-keys s fields)))
 
-(defmethod spec-for :union-definition [s {:keys [type-name type-names]}]
+(defmethod spec-for :union-definition [{:keys [type-name type-names]} s]
   (register-idempotent s [type-name] (cons 'clojure.spec/or (->> type-names
                                                                  (map (comp (partial named-spec s) vector))
                                                                  type-names->args))))
 
-;; TODO reverse order of s and n to be standard
-(defmethod spec-for :enum-definition [s {:keys [type-name fields]}]
+(defmethod spec-for :enum-definition [{:keys [type-name fields]} s]
   (register-idempotent s [type-name] (set (map :name fields))))
 
-;; TODO what if some fields on the associated type are required?
-(defmethod spec-for :fragment-definition [s {:keys [v/path] :as n}]
-  (register-idempotent (dissoc s :schema-hash) ["frag" (:name n)] (named-spec s path))) ;; alternatively, (to-keys s selection-set)
+(defmethod spec-for :fragment-definition [{:keys [v/path] :as n} s]
+  (register-idempotent (dissoc s :schema-hash) ["frag" (:name n)] (named-spec s path)))
 
-(defmethod spec-for :inline-fragment [s {:keys [v/path] :as n}]
+(defmethod spec-for :inline-fragment [{:keys [v/path]} s]
   [(named-spec s [(last path)])])
 
-(defmethod spec-for :fragment-spread [s n]
+(defmethod spec-for :fragment-spread [n s]
   [(named-spec (dissoc s :schema-hash) ["frag" (:name n)])])
 
-(defmethod spec-for :interface-definition [s {:keys [type-name fields]}]
+(defmethod spec-for :interface-definition [{:keys [type-name fields]} s]
   (register-idempotent s [type-name] (to-keys s fields)))
 
-(defmethod spec-for :list [s {:keys [v/path] :as n}]
-  (register-idempotent s path (coll-of s n)))
+(defmethod spec-for :list [{:keys [v/path] :as n} s]
+  (register-idempotent s path (coll-of n s)))
 
-(defn- register-type-field [s {:keys [v/path] :as n}]
+(defn- register-type-field [{:keys [v/path] :as n} s]
   (if (and (= (count path) 1) (= (:type-name n) (first path)))
     [(named-spec s [(to-type-name n)])]
     (register-idempotent s path (named-spec s [(to-type-name n)]))))
 
-(defmethod spec-for :type-field [s {:keys [v/path kind] :as n}]
+(defmethod spec-for :type-field [{:keys [v/path kind] :as n} s]
   (if (= :LIST kind)
-    (register-idempotent s path (coll-of s n))
-    (register-type-field s n)))
+    (register-idempotent s path (coll-of n s))
+    (register-type-field n s)))
 
-(defmethod spec-for :input-type-field [s {:keys [v/path kind] :as n}]
+(defmethod spec-for :input-type-field [{:keys [v/path kind] :as n} s]
   (if (= :LIST kind)
-    (register-idempotent s path (coll-of s n))
-    (register-type-field s n)))
+    (register-idempotent s path (coll-of n s))
+    (register-type-field n s)))
 
-(defmethod spec-for :field [s {:keys [v/path v/parent]}]
+(defmethod spec-for :field [{:keys [v/path v/parent]} s]
   [(named-spec s (if (= :inline-fragment (:node-type parent))
                    [(last (butlast path)) (last path)] ;; Ignore hierarchy for inline fragments
                    path))])
 
-(defmethod spec-for :argument [s {:keys [v/path v/parent] :as n}]
+(defmethod spec-for :argument [{:keys [v/path v/parent]} s]
   (case (:node-type parent)
     :field      [(named-spec s (into ["arg"] path))]
     :directive  [(directive-spec-name (-> parent :v/path last) (last path))]))
 
-(defmethod spec-for :type-field-argument [s {:keys [v/path kind] :as n}]
+(defmethod spec-for :type-field-argument [{:keys [v/path kind] :as n} s]
   (if (= :LIST kind)
-    (register-idempotent s (into ["arg"] path) (coll-of s n))
+    (register-idempotent s (into ["arg"] path) (coll-of n s))
     (register-idempotent s (into ["arg"] path) (named-spec s [(to-type-name n)]))))
 
 (defmethod spec-for :default [_ _])
@@ -239,7 +237,7 @@
 
 (def add-spec)
 (v/defmapvisitor add-spec :post [n s]
-  (when-let [[spec-name spec-def] (spec-for s n)]
+  (when-let [[spec-name spec-def] (spec-for n s)]
     (let [updated-n (-> n (assoc :spec spec-name))]
       (cond-> {:node (dissoc updated-n :v/parent)}
               spec-def (assoc :state (-> s

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -5,8 +5,7 @@
             [graphql-clj.error :as ge]
             [zip.visit :as zv]
             [graphql-clj.visitor :refer [defnodevisitor]]
-            [graphql-clj.type :as type]
-            [clojure.future :refer :all])
+            [graphql-clj.type :as type])
   (:import [clojure.lang Compiler$CompilerException]))
 
 (def base-ns "graphql-clj")
@@ -16,19 +15,37 @@
 (defn- append-pathlast [path s]
   (conj (butlast path) (str (last path) s)))
 
-(defn- ?? [pred v] (or (nil? v) (pred v)))
-(def int?? (partial ?? int?))
-(def double?? (partial ?? double?))
-(def string?? (partial ?? string?))
-(def boolean?? (partial ?? boolean?))
-(def id?? (partial ?? string?))
+(defn- boolean?* ;; TODO remove after clojure 1.9
+  "From clojure.future: Return true if x is a Boolean"
+  [x] (instance? Boolean x))
+
+(defn- int?* ;; TODO remove after clojure 1.9
+  "From clojure.future: Return true if x is a fixed precision integer"
+  [x] (or (instance? Long x)
+          (instance? Integer x)
+          (instance? Short x)
+          (instance? Byte x)))
+
+(defn- double?* ;; TODO remove after clojure 1.9
+  "From clojure.future: Return true if x is a Double"
+  [x] (instance? Double x))
+
+(defn- ??
+  "Allow nil as well as a predicate"
+  [pred v] (or (nil? v) (pred v)))
+
+(def int??     (partial ?? int?*))
+(def double??  (partial ?? double?*))
+(def string??  (partial ?? string?))
+(def boolean?? (partial ?? boolean?*))
+(def id??      (partial ?? string?))
 
 (def default-specs
-  {"Int!"     int?     "Int"     int??
-   "Float!"   double?  "Float"   double??
-   "String!"  string?  "String"  string??
-   "Boolean!" boolean? "Boolean" boolean??
-   "ID!"      string?  "ID"      string??})
+  {"Int!"     int?*     "Int"     int??
+   "Float!"   double?*  "Float"   double??
+   "String!"  string?   "String"  string??
+   "Boolean!" boolean?* "Boolean" boolean??
+   "ID!"      string?   "ID"      string??})
 
 (def default-spec-keywords ;; Register specs for global base / default / scalar types
   (set (mapv (fn [[n pred]] (eval (list 'clojure.spec/def (keyword base-ns n) pred))) default-specs)))

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -5,7 +5,8 @@
             [graphql-clj.error :as ge]
             [zip.visit :as zv]
             [graphql-clj.visitor :refer [defnodevisitor]]
-            [graphql-clj.type :as type])
+            [graphql-clj.type :as type]
+            [clojure.future :refer :all])
   (:import [clojure.lang Compiler$CompilerException]))
 
 (def base-ns "graphql-clj")

--- a/src/graphql_clj/validator/rules/no_undefined_variables.clj
+++ b/src/graphql_clj/validator/rules/no_undefined_variables.clj
@@ -12,7 +12,7 @@
 (defnodevisitor undefined-variable :pre :argument
   [{:keys [variable-name] :as n} s]
   (when variable-name                                       ;; TODO we can use the variable-usages for this
-    (when-not (s/get-spec (spec/spec-for s {:node-type :variable-usage :variable-name variable-name}))
+    (when-not (s/get-spec (spec/spec-for {:node-type :variable-usage :variable-name variable-name} s))
       {:state (ve/update-errors s (undefined-variable-error n))})))
 
 (def rules [undefined-variable])

--- a/src/graphql_clj/validator/rules/variables_in_allowed_position.clj
+++ b/src/graphql_clj/validator/rules/variables_in_allowed_position.clj
@@ -48,7 +48,7 @@
 (defnodevisitor variable-type-mismatch :post :argument
   [{:keys [spec variable-name] :as n} s]
   (let [arg-type (s/get-spec spec)
-        var-spec (spec/spec-for s {:node-type :variable-usage :variable-name variable-name})
+        var-spec (spec/spec-for {:node-type :variable-usage :variable-name variable-name} s)
         var-type (s/get-spec var-spec)
         var-def  (spec/get-type-node var-spec s)]
     (when-not (subtype-of s (effective-type var-type var-def) arg-type)

--- a/src/graphql_clj/visitor.clj
+++ b/src/graphql_clj/visitor.clj
@@ -81,7 +81,10 @@
         (map? node) (->> (get node-type->children (:node-type node))
                          (mapcat (partial children-w-path initial-state node)))))
 
-(defn- make-node [node children]
+(defn- make-node
+  "Given a node and a sequence of visited child nodes, return the node for the output tree.
+   Preserve the original key at which children were initially found."
+  [node children]
   (if (map? node)
     (merge node (group-by :v/parentk children))
     children))
@@ -142,5 +145,6 @@
 (defn visit-document
   ([document visitor-fns] (visit-document document (initial-state document) visitor-fns))
   ([document initial-state visitor-fns]
-   (-> (reduce #(update-document %1 %2 visitor-fns) {:document document :state initial-state} document-sections)
-       (update :document nodes->map))))
+   (let [initial-doc {:document document :state initial-state}]
+     (-> (reduce #(update-document %1 %2 visitor-fns) initial-doc document-sections)
+         (update :document nodes->map)))))


### PR DESCRIPTION
I've seen a number of different libraries that do not yet work with Clojure 1.9, so it seems premature to force this on the library user today given the use of spec.

Also, refactor spec namespace to consistently put node before state, as in the visitors / validators.
