### PR TITLE
Support for Input Objects and their fields in Introspection Schema

### DIFF
--- a/src/graphql_clj/introspection.clj
+++ b/src/graphql_clj/introspection.clj
@@ -61,7 +61,9 @@
                    (:fields type))
 
      ;; INPUT_OBJECT only
-     :inputFields [] ; TODO
+     :inputFields (when (= :INPUT_OBJECT (:kind type))
+                    (assert (:fields type) (format "input fields is empty for type: %s." type))
+                    (:fields type))
 
      ;; NON_NULL and LIST only
      ;; :ofType nil
@@ -71,8 +73,9 @@
 (defn schema-types [schema]
   (->> (concat (vals (:types schema))
                (vals (:interfaces schema))
-               (vals (:enums schema)))
-      (map type-resolver)))
+               (vals (:enums schema))
+               (vals (:inputs schema)))
+       (map type-resolver)))
 
 (defn field-resolver [field]
   (assert (:field-name field) (format "field name is null for field: %s." field))
@@ -89,6 +92,18 @@
    :isDeprecated false ; TODO
    :deprecationReason nil ; TODO
    })
+
+(defn input-field-resolver [field]
+  (assert (:field-name field) (format "field name is null for input value: %s." field))
+  {:name (:field-name field)
+   :description (:description field)
+
+   :type-name (:type-name field)
+   :kind (:kind field)
+   :inner-type (:inner-type field)
+   :required (:required field)
+
+   :default-value (:default-value field)})
 
 (defn enum-resolver [enum]
   {:name (:name enum)

--- a/src/graphql_clj/resolver.clj
+++ b/src/graphql_clj/resolver.clj
@@ -42,6 +42,8 @@
                              (map introspection/field-resolver (:fields parent)))
        ["__Type" "enumValues"] (fn [context parent args]
                                  (map introspection/enum-resolver (:enumValues parent)))
+       ["__Type" "inputFields"] (fn [context parent args]
+                                  (map introspection/input-field-resolver (:inputFields parent)))
        ["__Field" "type"] (fn [context parent args]
                             (cond
                               (:required parent) (introspection/type-resolver parent)


### PR DESCRIPTION
With this change in place, schemas like the following work successfully with the type instrospection query. This fixes getting GraphiQL auto-completion popups for input objects and their fields:

```graphql
schema {
  query: QueryRoot
}

input WorldInput {
  text: String
}

type QueryRoot {
  hello(world: WorldInput): String
}
```