### PR TITLE
Simplify process of establishing base type for fields, arguments, and variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ All notable changes to this project will be documented in this file. This change
 - Bugfix - required arguments fulfilled by required variables
 - Test - Add case for execution on field arguments with variable bindings
 - Test - Add preparation and memoization as an example in executor test
-
-
 - Add starwars test case from the `graphql-clj-starter project`
 
 ## [0.1.19] - 2016-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+- Simplify process of establishing base type for fields, arguments, and variables
 
 ## [0.1.20] - 2016-11-19
 - Build arguments, expand fragments, and inline types prior to execution phase

--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ This library uses clojure.spec for validation.  If you are not yet using clojure
     (def query-str "query {user {name age}}")
     (def context nil)
 
-    # Consider memoizing the result of parsing and validating the query before execution
+    ;; Consider memoizing the result of parsing and validating the query before execution
     (def query (-> query-str parser/parse (validator/validate-statement type-schema)))
     (executor/execute context type-schema resolver-fn query)
     ;; => {:data {"user" {"name" "test user name", "age" 30}}}
 
-    # Alternatively, you can still pass the query string (slower, for backwards compatibility)
+    ;; Alternatively, you can still pass the query string (slower, for backward compatibility)
     (executor/execute context type-schema resolver-fn query-str)
 
 ```

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -312,7 +312,8 @@
 (defn- safe-eval [recursive? {:keys [d m] :as spec-def}]
   (if (or recursive? (not (:recursive m)))
     (do
-      (assert (= (first d) 'clojure.spec/def))                      ;; Protect against unexpected statement eval
+      (assert (= (first d) 'clojure.spec/def))                      ;; Some protection against unexpected statement eval
+      (assert (= 3 (count d)))
       (try (eval d) (catch Compiler$CompilerException _ spec-def))) ;; Squashing errors here to provide better error messages in validation
     spec-def))
 

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -208,11 +208,15 @@
   (register-idempotent s [type-name] (set (map :name fields)) {}))
 
 (defmethod spec-for :fragment-definition [{:keys [v/path] :as n} s] ;; TODO fragment spec is equivalent to the type condition spec, when it should be a subset of those fields
-  (let [base-spec (named-spec s path)]
-    (register-idempotent (dissoc s :schema-hash) ["frag" (:name n)] base-spec {:base-spec base-spec})))
+  (let [base-spec (named-spec s path)
+        base-type-node (get-type-node base-spec s)]
+    (register-idempotent (dissoc s :schema-hash) ["frag" (:name n)] base-spec {:base-spec base-spec
+                                                                               :kind (:kind base-type-node)})))
 
 (defmethod spec-for :inline-fragment [{:keys [v/path]} s]
-  {:n (named-spec s [(last path)]) :m {}})
+  (let [spec (named-spec s [(last path)])
+        base-type-node (get-type-node spec s)]
+    {:n spec :m {:base-spec spec :kind (:kind base-type-node)}}))
 
 (defmethod spec-for :fragment-spread [n s]
   {:n (named-spec (dissoc s :schema-hash) ["frag" (:name n)]) :m {}})

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -1,4 +1,4 @@
-(ns graphql-clj.spec                                        ;; TODO move to graphql-clj.type
+(ns graphql-clj.spec
   (:require [clojure.spec :as s]
             [clojure.string :as str]
             [graphql-clj.visitor :as v]

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -135,7 +135,7 @@
   (when (keyword? spec)
     (let [spec-name (name spec)]
       (if (default-type-names spec-name)
-        (cond-> {:node-type :scalar :type-name spec-name :kind :SCALAR} ;; TODO add to spec map eagerly
+        (cond-> {:node-type :scalar :type-name spec-name :kind :SCALAR :spec spec} ;; TODO add to spec map eagerly
                 (not (s/valid? spec nil)) (assoc :required true))
         (get-in s [:spec-map spec])))))
 
@@ -264,7 +264,7 @@
                                             :else (do n (conj (:v/path parent-node) (last resolved-path)))))
         m (cond-> {}
                   parent-type-name (assoc :parent-type-name parent-type-name)
-                  base-named-spec  (assoc :base-name (name base-named-spec)))]
+                  base-named-spec  (assoc :base-spec base-named-spec))]
     (cond (default-spec-keywords base-named-spec)
           {:n (named-spec s (map str path)) :m m}
 
@@ -278,7 +278,7 @@
 (defmethod spec-for :argument [{:keys [v/path v/parent]} s]
   (let [path (if (> (count path) 3) (resolve-path path) path)]
     (case (:node-type parent)
-      :field     (let [n (named-spec s (into ["arg"] path))] {:n n :m {:base-name (some-> n (get-base-type-node s) :type-name)}})
+      :field     (let [n (named-spec s (into ["arg"] path))] {:n n :m {:base-spec (some-> n (get-base-type-node s) :spec)}})
       :directive {:n (directive-spec-name (-> parent :v/path last) (last path)) :m {}})))
 
 (defmethod spec-for :type-field-argument [{:keys [v/path kind] :as n} s]

--- a/src/graphql_clj/spec.clj
+++ b/src/graphql_clj/spec.clj
@@ -135,11 +135,11 @@
   (when (keyword? spec)
     (let [spec-name (name spec)]
       (if (default-type-names spec-name)
-        (cond-> {:node-type :scalar :type-name spec-name :kind :SCALAR :spec spec} ;; TODO add to spec map eagerly
+        (cond-> {:node-type :scalar :type-name spec-name :kind :SCALAR :spec spec}
                 (not (s/valid? spec nil)) (assoc :required true))
         (get-in s [:spec-map spec])))))
 
-(defn get-base-type-node                                    ;; TODO deprecate?
+(defn- get-base-type-node
   "Given a spec, get the node definition for the corresponding base type"
   [spec s]
   (let [base-spec* (s/get-spec spec)
@@ -195,10 +195,10 @@
     (if required coll-list (list 'clojure.spec/nilable coll-list))))
 
 (defmethod spec-for :variable-definition [{:keys [variable-name kind] :as n} s]
-  ; m {:base-spec (named-spec s [(to-type-name n)]) :kind kind :required required}] ;; TODO adding m here causes tests to fail
   (if (= :LIST kind)
-    (register-idempotent (dissoc s :schema-hash) ["var" variable-name] (coll-of n s) {})
-    (register-idempotent (dissoc s :schema-hash) ["var" variable-name] (named-spec s [(to-type-name n)]) {})))
+    (register-idempotent (dissoc s :schema-hash) ["var" variable-name] (coll-of n s) (get-base-metadata (of-type n s) s))
+    (let [spec (named-spec s [(to-type-name n)])]
+      (register-idempotent (dissoc s :schema-hash) ["var" variable-name] spec (get-base-metadata spec s)))))
 
 (defmethod spec-for :variable-usage [{:keys [variable-name]} s]
   {:n (named-spec (dissoc s :schema-hash) ["var" variable-name]) :m {}})

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -5,9 +5,9 @@
             [graphql-clj.box :as box]
             [clojure.spec :as s]))
 
-(defn- bad-value-error [{:keys [spec base-name argument-name value]}]
+(defn- bad-value-error [{:keys [spec base-spec argument-name value]}]
   {:error (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
-                  argument-name base-name (ve/unboxed-render value) (ve/explain-invalid spec value))
+                  argument-name (name base-spec) (ve/unboxed-render value) (ve/explain-invalid spec value))
    :loc   (ve/extract-loc (meta value))})
 
 (defnodevisitor bad-value :pre :argument

--- a/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
+++ b/src/graphql_clj/validator/rules/arguments_of_correct_type.clj
@@ -5,11 +5,10 @@
             [graphql-clj.box :as box]
             [clojure.spec :as s]))
 
-(defn- bad-value-error [{:keys [spec argument-name value]}]
-  (let [type-name (name (s/get-spec spec))]
-    {:error (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
-                    argument-name type-name (ve/unboxed-render value) (ve/explain-invalid spec value))
-     :loc (ve/extract-loc (meta value))}))
+(defn- bad-value-error [{:keys [spec base-name argument-name value]}]
+  {:error (format "Argument '%s' of type '%s' has invalid value: %s. Reason: %s."
+                  argument-name base-name (ve/unboxed-render value) (ve/explain-invalid spec value))
+   :loc   (ve/extract-loc (meta value))})
 
 (defnodevisitor bad-value :pre :argument
   [{:keys [spec value v/path] :as n} s]

--- a/src/graphql_clj/validator/rules/fields_on_correct_type.clj
+++ b/src/graphql_clj/validator/rules/fields_on_correct_type.clj
@@ -5,14 +5,14 @@
             [graphql-clj.validator.errors :as ve]
             [clojure.spec :as s]))
 
-(defn- missing-type-error [{:keys [spec parent-type-name base-spec] :as n}]
-  {:error (format "Cannot query field '%s' on type '%s'." (name spec) (name (or parent-type-name base-spec)))
+(defn- missing-type-error [{:keys [spec parent-type-name] :as n}]
+  {:error (format "Cannot query field '%s' on type '%s'." (name spec) parent-type-name)
    :loc   (ve/extract-loc (meta n))})
 
 ;; TODO allowed meta field such as __typename?
 
 (defnodevisitor missing-type :pre :field
-  [{:keys [spec base-spec v/path] :as n} s]
+  [{:keys [spec v/path] :as n} s]
   (when-not (s/get-spec spec)
     {:state (ve/update-errors s (missing-type-error n))
      :break true}))

--- a/src/graphql_clj/validator/rules/fields_on_correct_type.clj
+++ b/src/graphql_clj/validator/rules/fields_on_correct_type.clj
@@ -5,14 +5,14 @@
             [graphql-clj.validator.errors :as ve]
             [clojure.spec :as s]))
 
-(defn- missing-type-error [{:keys [spec parent-type-name base-name] :as n}]
-  {:error (format "Cannot query field '%s' on type '%s'." (name spec) (or parent-type-name base-name))
+(defn- missing-type-error [{:keys [spec parent-type-name base-spec] :as n}]
+  {:error (format "Cannot query field '%s' on type '%s'." (name spec) (name (or parent-type-name base-spec)))
    :loc   (ve/extract-loc (meta n))})
 
 ;; TODO allowed meta field such as __typename?
 
 (defnodevisitor missing-type :pre :field
-  [{:keys [spec v/path] :as n} s]
+  [{:keys [spec base-spec v/path] :as n} s]
   (when-not (s/get-spec spec)
     {:state (ve/update-errors s (missing-type-error n))
      :break true}))

--- a/src/graphql_clj/validator/rules/fields_on_correct_type.clj
+++ b/src/graphql_clj/validator/rules/fields_on_correct_type.clj
@@ -3,29 +3,18 @@
    parent type, or are an allowed meta field such as __typename."
   (:require [graphql-clj.visitor :refer [defnodevisitor]]
             [graphql-clj.validator.errors :as ve]
-            [clojure.spec :as s]
-            [graphql-clj.spec :as spec]))
+            [clojure.spec :as s]))
 
-(defn- type-label [{:keys [spec] :as n} s]
-  (name (or (s/get-spec spec) (let [p (spec/get-parent-type n s)]
-                                (if-let [parent-spec (s/get-spec p)]
-                                  (if (keyword? parent-spec) parent-spec p)
-                                  p)))))
-
-(defn- safe-type-label [{:keys [v/path] :as n} s]
-  (if (= 2 (count path)) (last (butlast path)) (type-label n s)))
-
-(defn- missing-type-error [{:keys [spec] :as n} s]
-  (let [type-label (safe-type-label n s)]
-    {:error (format "Cannot query field '%s' on type '%s'." (name spec) type-label)
-     :loc   (ve/extract-loc (meta n))}))
+(defn- missing-type-error [{:keys [spec parent-type-name base-name] :as n}]
+  {:error (format "Cannot query field '%s' on type '%s'." (name spec) (or parent-type-name base-name))
+   :loc   (ve/extract-loc (meta n))})
 
 ;; TODO allowed meta field such as __typename?
 
 (defnodevisitor missing-type :pre :field
   [{:keys [spec v/path] :as n} s]
   (when-not (s/get-spec spec)
-    {:state (ve/update-errors s (missing-type-error n s))
+    {:state (ve/update-errors s (missing-type-error n))
      :break true}))
 
 (def rules [missing-type])

--- a/src/graphql_clj/validator/rules/fragments_on_composite_types.clj
+++ b/src/graphql_clj/validator/rules/fragments_on_composite_types.clj
@@ -3,31 +3,29 @@
    can only be spread into a composite type (object, interface, or union), the
    type condition must also be a composite type."
   (:require [graphql-clj.visitor :refer [defnodevisitor]]
-            [graphql-clj.validator.errors :as ve]
-            [graphql-clj.spec :as spec]))
+            [graphql-clj.validator.errors :as ve]))
 
-(defn- composite-type-error
-  ([{:keys [spec] :as n}]
-   {:error (format "Fragment cannot condition on non composite type '%s'." (name spec))
-    :loc   (ve/extract-loc (meta n))})
-  ([{:keys [spec] :as n} base-type-node]
-   {:error (format "Fragment '%s' cannot condition on non composite type '%s'." (name spec) (name (:spec base-type-node)))
-    :loc   (ve/extract-loc (meta n))}))
+(defn- inline-composite-type-error [{:keys [base-spec] :as n}]
+  {:error (format "Fragment cannot condition on non composite type '%s'." (name base-spec))
+   :loc   (ve/extract-loc (meta n))})
+
+(defn- composite-type-error [{:keys [spec base-spec] :as n}]
+  {:error (format "Fragment '%s' cannot condition on non composite type '%s'." (name spec) (name base-spec))
+   :loc   (ve/extract-loc (meta n))})
 
 (def acceptable-kinds #{:OBJECT :INTERFACE :UNION})
 
 (defnodevisitor fragment-type-inline :pre :inline-fragment
-  [{:keys [spec] :as n} s]
-  (when-not (acceptable-kinds (:kind (spec/get-type-node spec s)))
-    {:state (ve/update-errors s (composite-type-error n))
+  [{:keys [spec kind] :as n} s]
+  (when-not (acceptable-kinds kind)
+    {:state (ve/update-errors s (inline-composite-type-error n))
      :break true}))
 
 (defnodevisitor fragment-type-def :pre :fragment-definition
-  [{:keys [spec] :as n} s]
-  (let [base-type-node (spec/get-base-type-node spec s)]
-    (when-not (acceptable-kinds (:kind base-type-node))
-      {:state (ve/update-errors s (composite-type-error n base-type-node))
-       :break true})))
+  [{:keys [spec kind] :as n} s]
+  (when-not (acceptable-kinds kind)
+    {:state (ve/update-errors s (composite-type-error n))
+     :break true}))
 
 (def rules [fragment-type-inline
             fragment-type-def])

--- a/src/graphql_clj/validator/rules/no_fragment_cycles.clj
+++ b/src/graphql_clj/validator/rules/no_fragment_cycles.clj
@@ -31,6 +31,7 @@
                    (accumulate-errors errors))]
         (reduce #(into %1 (detect-cycles (spec/get-type-node (:spec %2) s') s')) (:errors s') non-errors))))) ;; TODO stackoverflow risk?
 
+;; TODO can cause hangs when combined with other validations
 (defnodevisitor fragment-cycles :pre :fragment-definition [n s]
   (when-let [cycles (detect-cycles n (assoc s :visited-frags #{} :spread-path []))]
     (when-not (empty? cycles)

--- a/src/graphql_clj/validator/rules/scalar_leafs.clj
+++ b/src/graphql_clj/validator/rules/scalar_leafs.clj
@@ -4,7 +4,7 @@
             [graphql-clj.validator.errors :as ve]
             [graphql-clj.spec :as spec]))
 
-(defn- required-subselection-error [{:keys [field-name base-spec]}]
+(defn- required-subselection-error [{:keys [field-name base-spec] :as n}]
   {:error (format "Field '%s' of type '%s' must have a selection of subfields." field-name (name base-spec))
    :loc   (ve/extract-loc (meta field-name))})
 
@@ -19,8 +19,8 @@
       (scalar-kinds kind)))
 
 (defnodevisitor non-scalar-leaf :pre :field
-  [{:keys [base-spec selection-set kind] :as n} s]
-  (let [scalar? (scalar? base-spec kind)]
+  [{:keys [base-spec selection-set of-kind] :as n} s]
+  (let [scalar? (scalar? base-spec (spec/base-of-kind n))]
     (cond (and scalar? selection-set)
           {:state (ve/update-errors s (no-subselection-allowed-error n))
            :break true}

--- a/src/graphql_clj/validator/rules/scalar_leafs.clj
+++ b/src/graphql_clj/validator/rules/scalar_leafs.clj
@@ -2,51 +2,30 @@
   "A GraphQL document is valid only if all leaf fields (fields without sub selections) are of scalar or enum types."
   (:require [graphql-clj.visitor :refer [defnodevisitor]]
             [graphql-clj.validator.errors :as ve]
-            [clojure.spec :as s]
             [graphql-clj.spec :as spec]))
 
-(defn- type-label [field-type spec]
-  (if (keyword? field-type) (name field-type) (name spec)))
+(defn- required-subselection-error [{:keys [field-name base-spec]}]
+  {:error (format "Field '%s' of type '%s' must have a selection of subfields." field-name (name base-spec))
+   :loc   (ve/extract-loc (meta field-name))})
 
-(defn- required-subselection-error [field-name field-type spec base-type]
-  (let [label (type-label field-type (type-label (:spec base-type) spec))]
-    {:error (format "Field '%s' of type '%s' must have a selection of subfields." field-name label)
-     :loc   (ve/extract-loc (meta field-name))}))
-
-(defn- no-subselection-allowed-error [field-name field-type spec]
-  (let [label (type-label field-type spec)]
-    {:error (format "Field '%s' must not have a selection since type '%s' has no subfields." field-name label)
-     :loc   (ve/extract-loc (meta field-name))}))
+(defn- no-subselection-allowed-error [{:keys [field-name base-spec]}]
+  {:error (format "Field '%s' must not have a selection since type '%s' has no subfields." field-name (name base-spec))
+   :loc   (ve/extract-loc (meta field-name))})
 
 (def scalar-kinds #{:SCALAR :ENUM})
 
-(defn get-type-node [field-type spec s]
-  (or (spec/get-type-node field-type s)
-      (spec/get-type-node spec s)))
-
-(defn base-type [field-type spec s]
-  (let [{:keys [kind inner-type] :as type-node} (get-type-node field-type spec s)
-        inner-spec (some->> inner-type :type-name name vector (spec/named-spec s))]
-    (cond (spec/default-spec-keywords spec) spec
-          (spec/default-spec-keywords field-type) field-type
-          (spec/default-spec-keywords inner-spec) inner-spec
-          (= :LIST kind) (spec/get-type-node inner-spec s)
-          :else type-node)))
-
-(defn scalar? [base-type]
-  (or (spec/default-spec-keywords base-type)
-      (scalar-kinds (:kind base-type))))
+(defn scalar? [base-spec kind]
+  (or (spec/default-spec-keywords base-spec)
+      (scalar-kinds kind)))
 
 (defnodevisitor non-scalar-leaf :pre :field
-  [{:keys [field-name spec selection-set] :as n} s]
-  (let [field-type (s/get-spec spec)
-        base-type  (base-type field-type spec s)
-        scalar?    (scalar? base-type)]
+  [{:keys [base-spec selection-set kind] :as n} s]
+  (let [scalar? (scalar? base-spec kind)]
     (cond (and scalar? selection-set)
-          {:state (ve/update-errors s (no-subselection-allowed-error field-name field-type spec))
+          {:state (ve/update-errors s (no-subselection-allowed-error n))
            :break true}
           (and (not scalar?) (not selection-set))
-          {:state (ve/update-errors s (required-subselection-error field-name field-type spec base-type))
+          {:state (ve/update-errors s (required-subselection-error n))
            :break true})))
 
 (def rules [non-scalar-leaf])

--- a/src/graphql_clj/validator/rules/unique_input_field_names.clj
+++ b/src/graphql_clj/validator/rules/unique_input_field_names.clj
@@ -18,7 +18,7 @@
         :else                                 v))
 
 (defn- mapify-object-value [v]
-  (with-meta (walk/postwalk object-value->map (last @v)) (meta v)))
+  (with-meta (walk/postwalk object-value->map (last (box/box->val v))) (meta v)))
 
 (defn- duplicate-input-operation
   "Check an object value for duplicate keys.  If there are none, convert the object value to a map."

--- a/src/graphql_clj/validator/rules/variables_are_input_types.clj
+++ b/src/graphql_clj/validator/rules/variables_are_input_types.clj
@@ -4,14 +4,14 @@
             [graphql-clj.validator.errors :as ve]
             [graphql-clj.spec :as spec]))
 
-(defn- bad-variable-type-error [{:keys [variable-name]} {:keys [spec]}]
+(defn- bad-variable-type-error [{:keys [variable-name]} {:keys [spec] :as type-node}]
   {:error (format "Variable '$%s' cannot be non-input type '%s'." variable-name (name spec))
    :loc   (ve/extract-loc (meta variable-name))})
 
 (def acceptable-types #{:scalar :enum-definition :input-definition :variable-definition})
 
 (defnodevisitor bad-variable-type :pre :variable-definition [n s]
-  (let [{:keys [node-type] :as type-node} (spec/get-base-type-node (:spec n) s)] ;; TODO use get-type-node with base spec here
+  (let [{:keys [node-type] :as type-node} (spec/get-type-node (:base-spec n) s)]
     (when-not (acceptable-types node-type)
       {:state (ve/update-errors s (bad-variable-type-error n type-node))
        :break true})))

--- a/src/graphql_clj/validator/rules/variables_are_input_types.clj
+++ b/src/graphql_clj/validator/rules/variables_are_input_types.clj
@@ -11,7 +11,7 @@
 (def acceptable-types #{:scalar :enum-definition :input-definition :variable-definition})
 
 (defnodevisitor bad-variable-type :pre :variable-definition [n s]
-  (let [{:keys [node-type] :as type-node} (spec/get-base-type-node (:spec n) s)]
+  (let [{:keys [node-type] :as type-node} (spec/get-base-type-node (:spec n) s)] ;; TODO use get-type-node with base spec here
     (when-not (acceptable-types node-type)
       {:state (ve/update-errors s (bad-variable-type-error n type-node))
        :break true})))

--- a/src/graphql_clj/validator/transformations/inline_types.clj
+++ b/src/graphql_clj/validator/transformations/inline_types.clj
@@ -2,7 +2,8 @@
   "Inline field and parent field types for execution phase"
   (:require [graphql-clj.visitor :as v]
             [graphql-clj.spec :as spec]
-            [clojure.spec :as s]))
+            [clojure.spec :as s]
+            [graphql-clj.box :as box]))
 
 (defn- of-kind [{:keys [kind required inner-type]} s]
   (if (:type-name inner-type)
@@ -15,19 +16,14 @@
     (if (keyword? base-spec) base-spec spec)
     spec))
 
-(def whitelisted-keys #{:v/parentk :node-type :selection-set :type-name :field-name :name :args-fn})
+(def whitelisted-keys
+  #{:v/parentk :node-type :selection-set :type-name :field-name :name :args-fn :kind :of-kind :required :parent-type-name})
 
 (declare inline-types)
 (v/defnodevisitor inline-types :post :field
-  [{:keys [field-name spec v/path v/parent] :as n} {:keys [resolver] :as s}]
-  (let [type-node (spec/get-type-node spec s)
-        {:keys [kind required] :as base} (if (:kind type-node) type-node (spec/get-base-type-node spec s))
-        parent-type-name (or  (some-> n (spec/get-parent-type s) name) (first path))]
-    {:node (cond-> (select-keys n whitelisted-keys)
-                   kind             (assoc :kind kind)
-                   required         (assoc :required required)
-                   (= :LIST kind)   (assoc :of-kind (of-kind base s))
-                   parent-type-name (assoc :parent-type-name parent-type-name)
-                   resolver         (assoc :resolver-fn (resolver parent-type-name field-name)))}))
+  [{:keys [field-name parent-type-name spec v/path v/parent] :as n} {:keys [resolver] :as s}]
+  {:node (cond-> (select-keys n whitelisted-keys)
+                 parent-type-name (assoc :parent-type-name (box/box->val parent-type-name))
+                 resolver (assoc :resolver-fn (resolver parent-type-name field-name)))})
 
 (def rules [inline-types])

--- a/src/graphql_clj/validator/transformations/inline_types.clj
+++ b/src/graphql_clj/validator/transformations/inline_types.clj
@@ -1,20 +1,7 @@
 (ns graphql-clj.validator.transformations.inline-types
   "Inline field and parent field types for execution phase"
   (:require [graphql-clj.visitor :as v]
-            [graphql-clj.spec :as spec]
-            [clojure.spec :as s]
             [graphql-clj.box :as box]))
-
-(defn- of-kind [{:keys [kind required inner-type]} s]
-  (if (:type-name inner-type)
-    (let [base (spec/get-type-node (spec/named-spec s [(:type-name inner-type)]) s)]
-      (select-keys base [:kind :required]))
-    {:kind kind :required required :of-kind (of-kind inner-type s)}))
-
-(defn- parent-type [{:keys [spec]}]
-  (if-let [base-spec (s/get-spec spec)]
-    (if (keyword? base-spec) base-spec spec)
-    spec))
 
 (def whitelisted-keys
   #{:v/parentk :node-type :selection-set :type-name :field-name :name :args-fn :kind :of-kind :required :parent-type-name})

--- a/test/graphql_clj/visitor_test.clj
+++ b/test/graphql_clj/visitor_test.clj
@@ -1,7 +1,6 @@
 (ns graphql-clj.visitor-test
   (:require [clojure.test :refer :all]
             [graphql-clj.visitor :as visitor]
-            [graphql-clj.spec :as spec]
             [clojure.data]))
 
 
@@ -46,8 +45,4 @@
 (deftest adding-path
   (testing "DFS traversal adding the path as we go"
     (is (= ["QueryRoot" "person" "id"]
-           (:v/path (get-person-arg (visitor/visit-document document []))))))
-
-  (testing "pre-order visit and add a spec to relevant nodes"
-    (is (= :graphql-clj.920397452.arg.QueryRoot.person/id
-           (:spec (get-person-arg (visitor/visit-document document [spec/add-spec])))))))
+           (:v/path (get-person-arg (visitor/visit-document document [])))))))


### PR DESCRIPTION
Centralize the responsibility for determining the base type for each field, argument, and variable in the spec namespace.  Better if this complexity doesn't leak into other namespaces.  Backward compatible.