### PR TITLE
.travis.yml to use openjdk8 rather vs oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: clojure
 script: lein test
 jdk:
-  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
Travis appears to be having problems with oracle java and the unencumbered openjdk is friendlier to the community and headless installations